### PR TITLE
add minutes link to gov index page

### DIFF
--- a/monorepo/website/src/pages/about/governance/index.mdx
+++ b/monorepo/website/src/pages/about/governance/index.mdx
@@ -20,6 +20,7 @@ You can read all of our governance and privacy documents and terms below.
 - [Data Submission and Processing](/about/governance/data_submission)
 - [Executive Board Guidelines](/about/governance/exec_board_guidelines)
 - [Scientific Advisory Board Guidelines](/about/governance/sa_board_guidelines)
+- [Meeting Minutes](/about/governance/minutes)
 
 
 # Privacy


### PR DESCRIPTION
Adds a link to the meeting minutes on the governance page index - in particular because we link to the governance page in the blog post, in a sentence that says we have publicly available minutes 🙃 