### PR TITLE
Typo fix in Terms of Service

### DIFF
--- a/monorepo/website/src/pages/about/terms-of-use/terms-of-service.mdx
+++ b/monorepo/website/src/pages/about/terms-of-use/terms-of-service.mdx
@@ -104,7 +104,7 @@ We will aim to give Users, Submitters, and Curators as much notice as possible i
 
 ## 8. Dispute Resolution
 
-These Terms and any other Terms governing or relating to Pathoplexus, are governed by the law of Switzerland. In the event of any such dispute or claim in connection with these Terms, you agree to first engage in good face discussion with us to resolve such a dispute or claim. If it cannot be resolved within sixty (60) days, settlement will be by arbitration under the courts of Switzerland.
+These Terms and any other Terms governing or relating to Pathoplexus, are governed by the law of Switzerland. In the event of any such dispute or claim in connection with these Terms, you agree to first engage in good faith discussion with us to resolve such a dispute or claim. If it cannot be resolved within sixty (60) days, settlement will be by arbitration under the courts of Switzerland.
 
 
 


### PR DESCRIPTION
"good face discussions" --> "good faith discussions"

SHOULD ONLY be merged after Chaoran's - and then only if file renaming doesn't break it.