### PR TITLE
Make use of different menu titles for some markdown pages

### DIFF
--- a/monorepo/website/src/pages/about/eb.mdx
+++ b/monorepo/website/src/pages/about/eb.mdx
@@ -1,6 +1,7 @@
 ---
 layout: ../../layouts/AboutLayout.astro
-title: 'Executive Board'
+menuTitle: 'Executive Board'
+title: Pathoplexus Executive Board
 route: /
 order: 2
 ---
@@ -40,7 +41,6 @@ export const members = [
     }
 ];
 
-# Pathoplexus Executive Board
 
 Pathoplexus is run by an Executive Board, who have dedicated themselves to following the 
 [Pathoplexus Values](/about/governance/values)

--- a/monorepo/website/src/pages/about/terms-of-use/open-data.mdx
+++ b/monorepo/website/src/pages/about/terms-of-use/open-data.mdx
@@ -1,6 +1,7 @@
 ---
 layout: ../../../layouts/AboutLayout.astro
-title: "Open Data Terms of Use (Summary)"
+title: Open Data Terms of Use
+menuTitle: Open Data Terms of Use (Summary)
 order: 2
 ---
 import MaterialSymbolsInfoOutline from '~icons/material-symbols/info-outline';

--- a/monorepo/website/src/pages/about/terms-of-use/restricted-data.mdx
+++ b/monorepo/website/src/pages/about/terms-of-use/restricted-data.mdx
@@ -1,6 +1,7 @@
 ---
 layout: ../../../layouts/AboutLayout.astro
-title: "Restricted Data Terms of Use (Summary)"
+title: Restricted Data Terms of Use
+menuTitle: Restricted Data Terms of Use (summary)
 order: 3
 ---
 import MaterialSymbolsInfoOutline from '~icons/material-symbols/info-outline';

--- a/monorepo/website/src/pages/about/terms-of-use/restricted-data.mdx
+++ b/monorepo/website/src/pages/about/terms-of-use/restricted-data.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/AboutLayout.astro
 title: Restricted Data Terms of Use
-menuTitle: Restricted Data Terms of Use (summary)
+menuTitle: Restricted Data Terms of Use (Summary)
 order: 3
 ---
 import MaterialSymbolsInfoOutline from '~icons/material-symbols/info-outline';


### PR DESCRIPTION
This PR makes use of a feature we added to Loculus which allows us optionally to have a different title in the docs menu and in the page title so that the Open Data doesn't need `(Summary)` at the top and the EB doesn't need two redundant titles.

https://preview-menutitle.pathoplexus.org/about/terms-of-use/open-data

<img width="1418" alt="image" src="https://github.com/user-attachments/assets/e782e51c-3e3e-4476-899a-6dcc89fe6323">
