### PR TITLE
Remove concurrency check from build

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -7,11 +7,6 @@ on:
 env:
   DOCKER_IMAGE_NAME: ghcr.io/pathoplexus/website
 
-
-concurrency:
-  group: ci-${{ github.ref == 'refs/heads/main' && github.run_id || github.ref }}-website
-  cancel-in-progress: true
-
 jobs:
 
   dockerImage:


### PR DESCRIPTION
We always want to build on pathoplexus, not to cancel builds to avoid concurrency