### PR TITLE
Add `PP_` prefix to production-specific values

### DIFF
--- a/loculus_values/environment_specific_values/production.yaml
+++ b/loculus_values/environment_specific_values/production.yaml
@@ -1,3 +1,4 @@
+accessionPrefix: "PP_"
 runDevelopmentMainDatabase: false
 runDevelopmentKeycloakDatabase: false
 bannerMessage: ""


### PR DESCRIPTION
This adds the `PP_` prefix to production-specific values (but they are still currently duplicated in the main pathoplexus `Values.yaml`) - this is another low-risk change

relates to #38