### PR TITLE
Tweak welcome message styling

### DIFF
--- a/monorepo/website/src/components/IndexPage/WelcomeMessage.astro
+++ b/monorepo/website/src/components/IndexPage/WelcomeMessage.astro
@@ -2,9 +2,9 @@
 
 ---
 
-<h2 class='text-lg text-gray-700'>Welcome to Pathoplexus!</h2>
+<h2 class='text-lg font-semibold text-main my-3 mt-6'>Welcome to Pathoplexus!</h2>
 
-<p class='text-gray-700 my-4'>
+<p class='my-4'>
     Pathoplexus is a new, open-source database dedicated to the efficient sharing of human viral pathogen genomic data,
     fostering global collaboration and public health response.
 </p>


### PR DESCRIPTION
This moves the top of the Pathoplexus page to be more in line with the rest of it.


https://preview-tweak-welcome-message-styling.pathoplexus.org/

<img width="1326" alt="image" src="https://github.com/user-attachments/assets/36056ac3-e116-485c-8bfa-31955dd19f28">


Previously it was a subtly different black (gray) as well as the difference in the heading colour.


