### PR TITLE
chore(config): don't send noindex robots header for production

### DIFF
--- a/loculus_values/environment_specific_values/production.yaml
+++ b/loculus_values/environment_specific_values/production.yaml
@@ -3,6 +3,7 @@ runDevelopmentMainDatabase: false
 runDevelopmentKeycloakDatabase: false
 bannerMessage: ""
 subdomainSeparator: "."
+noindex: false
 secrets:
   keycloak-admin:
     type: sealedsecret


### PR DESCRIPTION
Follow up to loculus-project/loculus#2657 to make production remain indexed.

This can be merged as soon as we agree on the Loculus PR, there's no harm in having an extra values.yaml that isn't used yet.

https://preview-do-index-production.pathoplexus.org