### PR TITLE
fix: make sure that the bug re/ unaligned sequences does not happen on pathoplexus by disabling dateToSortBy optimization

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1048,8 +1048,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         - length
       defaultOrderBy: sampleCollectionDate
       defaultOrder: descending
-    silo:
-      dateToSortBy: sampleCollectionDate
     extraInputFields: &extraInputFields
       - name: submissionId
         displayName: Submission ID


### PR DESCRIPTION
The recent SILO PR https://github.com/GenSpectrum/LAPIS-SILO/pull/549 contains a bugfix that was reproduced when dateToSortBy is set, to prevent this bug from happening on pathoplexus, I would disable this field before we wait for the change to be propagated upstream