### PR TITLE
Restyle frontpage FAQ and bump loculus to 67d1b810721cf0d9164edfb24ec68920cebbb485

### DIFF
--- a/monorepo/website/src/components/IndexPage/FAQ.mdx
+++ b/monorepo/website/src/components/IndexPage/FAQ.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Frequently Asked Questions (FAQ)"
 ---
-<div class="faq">
+<div class="faqWrapper">
 
 ### What makes Pathoplexus different?
 Pathoplexus offers flexible data-sharing options: users can choose to share their data openly, or with time-limited protections to help ensure proper attribution and credit. 

--- a/monorepo/website/src/components/IndexPage/FAQ.mdx
+++ b/monorepo/website/src/components/IndexPage/FAQ.mdx
@@ -41,6 +41,8 @@ See our [About](/about) page for more information about Pathoplexus, and our [Ex
 about some of the people involved.
 
 ### Where can I read more?
+
+<div class="indent">
 - You can read more about the purpose of Pathoplexus and our pledges to the community in our [Pathoplexus Values](/about/governance/values).
 - You can read about the legal structure of Pathoplexus and how it runs in our [Statutes](/about/governance/pathoplexus-statutes)
 - To find out more about how data in Pathoplexus can be used and must be credited, see our [Data Use Terms](/about/terms-of-use/data-use-terms).
@@ -48,6 +50,7 @@ about some of the people involved.
 - To find out more about our Governance, see our [list of Governance documents](/about/governance).
 - To read more about how to use Pathoplexus, check out our ['How-To' documents](/docs/how-to).
 - To become part of the scientific community that helps drive Pathoplexus, you can join [PHA4GE](https://pha4ge.org/) and be part of the Data Repositories Working Group
+</div>
 
 [_See more of our Frequently Asked Questions here!_](/about/faq)
 

--- a/monorepo/website/src/components/IndexPage/FAQ.mdx
+++ b/monorepo/website/src/components/IndexPage/FAQ.mdx
@@ -1,6 +1,7 @@
 ---
 title: "Frequently Asked Questions (FAQ)"
 ---
+<div class="faq">
 
 ### What makes Pathoplexus different?
 Pathoplexus offers flexible data-sharing options: users can choose to share their data openly, or with time-limited protections to help ensure proper attribution and credit. 
@@ -51,3 +52,4 @@ about some of the people involved.
 [_See more of our Frequently Asked Questions here!_](/about/faq)
 
 
+</div>

--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 3a74415a9cad30a9694a8b772ee36858cf699282
+loculusVersion: 6d3e70f56872b6fe8f6ebd354ead4da51d8d302e
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy

--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 6d3e70f56872b6fe8f6ebd354ead4da51d8d302e
+loculusVersion: e4354630f2371c9127c2a08d3bdb7c483c5f007b
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy

--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 7f2b9500189f32e0ad5d2cf6fbc03a612f43ed7b
+loculusVersion: 3a74415a9cad30a9694a8b772ee36858cf699282
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy

--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 7b2701c8d783cad24527f120f743deeb65aa967d
+loculusVersion: 67d1b810721cf0d9164edfb24ec68920cebbb485
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy

--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: e4354630f2371c9127c2a08d3bdb7c483c5f007b
+loculusVersion: f27d47057056dd978058941d900efc719fef3586
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy

--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: f27d47057056dd978058941d900efc719fef3586
+loculusVersion: 7b2701c8d783cad24527f120f743deeb65aa967d
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
Adds separators to the front page FAQ:
<img width="797" alt="image" src="https://github.com/user-attachments/assets/4964d04e-2260-431a-90dc-5beb9c21c13e">

https://preview-frontfaq.pathoplexus.org/

To use this we would merge https://github.com/loculus-project/loculus/pull/2669 and then update to latest Loculus