### PR TITLE
Update example data links to point to new GitHub pages version

### DIFF
--- a/loculus_values/environment_specific_values/staging.yaml
+++ b/loculus_values/environment_specific_values/staging.yaml
@@ -1,7 +1,7 @@
 runDevelopmentMainDatabase: false
 runDevelopmentKeycloakDatabase: false
 accessionPrefix: "PPD_"
-bannerMessage: "This is a demo instance. You can upload any data you like, including test data to try things out. You can find test data to upload in the <a href='https://github.com/pathoplexus/example_data' class='font-semibold underline'>example data</a> repository. This instance should not be used for analysis."
+bannerMessage: "This is a demo instance. You can upload any data you like, including test data to try things out. You can find test data to upload in the <a href='https://pathoplexus.github.io/example_data/' class='font-semibold underline'>example data</a> repository. This instance should not be used for analysis."
 secrets:
   keycloak-admin:
     type: sealedsecret

--- a/monorepo/website/src/components/IndexPage/FAQ.mdx
+++ b/monorepo/website/src/components/IndexPage/FAQ.mdx
@@ -26,7 +26,7 @@ can always use our [Demo Instance](https://demo.pathoplexus.org/)! Our Demo Inst
 
 It's perfect for trying out Pathoplexus or testing your API requests. Do note that since it is wiped regularly, you will have to make a new account and group - but it's ok if these aren't as detailed
 as your 'real' accounts. Remember that the Demo Instance is public, so don't upload data that you can't or don't want to share. If you'd like to try out Pathoplexus but don't have any data to hand, you can use our 
-[example data](https://github.com/pathoplexus/example_data) for the pathogens we support!
+[example data](https://pathoplexus.github.io/example_data/) for the pathogens we support!
 
 _(See our [Docs](/docs) for more information on how to do things like create an account, upload sequences, and more in Pathoplexus!)_
 

--- a/monorepo/website/src/pages/about/faq.mdx
+++ b/monorepo/website/src/pages/about/faq.mdx
@@ -65,7 +65,7 @@ can always use our [Demo Instance](https://demo.pathoplexus.org/)! Our Demo Inst
 
 It's perfect for trying out Pathoplexus or testing your API requests. Do note that since it is wiped regularly, you will have to make a new account and group - but it's ok if these aren't as detailed
 as your 'real' accounts. Remember that the Demo Instance is public, so don't upload data that you can't or don't want to share. If you'd like to try out Pathoplexus but don't have any data to hand, you can use our 
-[example data](https://github.com/pathoplexus/example_data) for the pathogens we support!
+[example data](https://pathoplexus.github.io/example_data/) for the pathogens we support!
 
 _(See our [Docs](/docs) for more information on how to do things like create an account, upload sequences, and more in Pathoplexus!)_
 

--- a/monorepo/website/src/pages/docs/how-to/upload-sequences.mdx
+++ b/monorepo/website/src/pages/docs/how-to/upload-sequences.mdx
@@ -15,7 +15,7 @@ Loculus expects:
 
 ![Metadata template.](../../../images/MetadataTemplate.png)
 
-_You can try out uploading sequences to our [Demo Instance](https://demo.pathoplexus.org/) - it works just like the 'real' Pathoplexus, but is wiped regularly and **no data is sent onward to INSDC**. We also have some [example data](https://github.com/pathoplexus/example_data) you can upload to the Demo Instance._
+_You can try out uploading sequences to our [Demo Instance](https://demo.pathoplexus.org/) - it works just like the 'real' Pathoplexus, but is wiped regularly and **no data is sent onward to INSDC**. We also have some [example data](https://pathoplexus.github.io/example_data/) you can upload to the Demo Instance._
 
 
 ### Multi-segmented Pathogens


### PR DESCRIPTION
Updates example data links to a new GitHub pages version I created (https://pathoplexus.github.io/example_data/) as discussed in:

https://github.com/pathoplexus/example_data/pull/1