### PR TITLE
feat: Add robots noindex headers to all but production

### DIFF
--- a/loculus_values/environment_specific_values/production.yaml
+++ b/loculus_values/environment_specific_values/production.yaml
@@ -2,7 +2,7 @@ accessionPrefix: "PP_"
 runDevelopmentMainDatabase: false
 runDevelopmentKeycloakDatabase: false
 bannerMessage: ""
-robotsNoindexHeader: true
+robotsNoindexHeader: false
 subdomainSeparator: "."
 secrets:
   keycloak-admin:

--- a/loculus_values/environment_specific_values/production.yaml
+++ b/loculus_values/environment_specific_values/production.yaml
@@ -2,6 +2,7 @@ accessionPrefix: "PP_"
 runDevelopmentMainDatabase: false
 runDevelopmentKeycloakDatabase: false
 bannerMessage: ""
+robotsNoindexHeader: true
 subdomainSeparator: "."
 secrets:
   keycloak-admin:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1,3 +1,4 @@
+robotsNoindexHeader: true
 registrationTermsMessage: >
   Do you agree to the <a href="https://pathoplexus.org/about/terms-of-use/terms-of-service">terms of use</a> and the <a href="https://pathoplexus.org/about/terms-of-use/privacy-policy">privacy policy</a>?
 runDevelopmentMainDatabase: true

--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 09241e97a6eb9bc26d7848f5bbc847b7907ba2ad
+loculusVersion: 61fb6757861f47fd9919f4e0db655cdf15b17a40
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
See https://github.com/loculus-project/loculus/pull/2657

https://preview-noindex-non-prod.pathoplexus.org

Also some small loculus changes are now included due to this PR updating loculus base commit https://github.com/loculus-project/loculus/compare/09241e97a6eb9bc26d7848f5bbc847b7907ba2ad...61fb6757861f47fd9919f4e0db655cdf15b17a40

<img width="1263" alt="image" src="https://github.com/user-attachments/assets/316bbd48-a8a1-44b8-baac-a78749d604a9">

That's what should happen:
<img width="766" alt="image" src="https://github.com/user-attachments/assets/e73e8a28-5196-4515-97b7-8afaf0c9a2df">
