### PR TITLE
ci: Add dependabot to bump actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
@theosanderson I think you used chatgpt to create many of the actions and chatgpt doesn't use latest ;)
