### PR TITLE
Adds Pardis to SAB

### DIFF
--- a/monorepo/website/src/pages/about/sab.mdx
+++ b/monorepo/website/src/pages/about/sab.mdx
@@ -18,7 +18,7 @@ export const members = [
     },
     {
         name: "Pardis Sabeti",
-        description: "Broad Institute, Harvard University",
+        description: "Broad Institute, Harvard University, HHMI",
         picture: pardisSabeti
     },
     {

--- a/monorepo/website/src/pages/about/sab.mdx
+++ b/monorepo/website/src/pages/about/sab.mdx
@@ -36,7 +36,7 @@ Pathoplexus recognizes that a diverse and active board is essential for maximizi
 
 The Pathoplexus Scientific Advisory Board is defined and guided by the [Scientific Board Board Guidelines](/about/governance/sab-guidelines).
 
-**More Scientific Advisory Board members will be announced soon.** <br />
+**More Scientific Advisory Board members will be announced soon.** <br /><br />
 
 <Team members={members} />
 

--- a/monorepo/website/src/pages/about/sab.mdx
+++ b/monorepo/website/src/pages/about/sab.mdx
@@ -8,12 +8,18 @@ order: 3
 import Team from '../../components/Team.astro'
 import mangShi from "../../images/mangShi-square.png"
 import sofoniasTessema from "../../images/sofoniasTessema-square.jpg"
+import pardisSabeti from "../../images/pardisSabeti-square.png"
 
 export const members = [
     {
         name: "Sofonias Tessema",
         description: "Africa CDC",
         picture: sofoniasTessema
+    },
+    {
+        name: "Pardis Sabeti",
+        description: "Broad Institute, Harvard University",
+        picture: pardisSabeti
     },
     {
         name: "Mang Shi",

--- a/monorepo/website/src/pages/about/sab.mdx
+++ b/monorepo/website/src/pages/about/sab.mdx
@@ -36,7 +36,7 @@ Pathoplexus recognizes that a diverse and active board is essential for maximizi
 
 The Pathoplexus Scientific Advisory Board is defined and guided by the [Scientific Board Board Guidelines](/about/governance/sab-guidelines).
 
-**More Scientific Advisory Board members will be announced soon.**
+**More Scientific Advisory Board members will be announced soon.** <br />
 
 <Team members={members} />
 


### PR DESCRIPTION
Simple PR to add Pardis to the SAB page, with photo, name, and description.

I am just double-checking with Pardis that she's happy with the affiliation, photo, etc. Then we'll be set to merge.

Pre-approval welcome though (can re-seek review if any substantial change)