### PR TITLE
News Item 13 Sept

### DIFF
--- a/monorepo/website/src/pages/news/2024-09-13-two-weeks.mdx
+++ b/monorepo/website/src/pages/news/2024-09-13-two-weeks.mdx
@@ -35,11 +35,10 @@ Here’s a short list of updates from our side, to celebrate two weeks of being 
 - Our code is open-source and on [GitHub](http://github.com/pathoplexus). Thank you to everyone from the community who have made suggestions for improvements to [Loculus](https://github.com/loculus-project/loculus/issues) (the software behind Pathoplexus). Since launch, we’ve added a few features and fixed some bugs. All enhancements and bug-fixes are documented on GitHub. Severe incidents with high impact will also be reported on this news page.
 
 ### Past talks:
-- Cornelius Roemer and Fabian Engelniederhammer gave a talk on Loculus at "TNG Big Techday 24," which you can [watch on Youtube](https://www.youtube.com/watch?v=wPtwH4siQyU)
+- Cornelius Roemer and Fabian Engelniederhammer gave a talk on Loculus at "TNG Big Techday 24" on 5 July 2024, which you can [watch on Youtube](https://www.youtube.com/watch?v=wPtwH4siQyU)
+- Tanja Stadler spoke about Pathoplexus and Loculus at [SIBE](https://www.sibe-iseb.it/napoli2024) (8-11 Sept, Napoli) and at [Inauguration of Alps Infrastructure](https://www.cscs.ch/events/upcoming-events/event-detail?tx_cscsevents_pi1%5Bcontroller%5D=Event&tx_cscsevents_pi1%5Bevent%5D=195&cHash=423f54c401a3f3f71b363a30ec0de932) (13 Sept, Hoenggerberg)
 
 ### Upcoming talks:
 - Now that we’ve launched, we’re keen to tell you more about Pathoplexus and Loculus! Look out for talks from our members at upcoming conferences:
-  - Tanja Stadler at [SIBE](https://www.sibe-iseb.it/napoli2024) (8-11 Sept, Napoli)
-  - Tanja Stadler at [Inauguration of Alps Infrastructure](https://www.cscs.ch/events/upcoming-events/event-detail?tx_cscsevents_pi1%5Bcontroller%5D=Event&tx_cscsevents_pi1%5Bevent%5D=195&cHash=423f54c401a3f3f71b363a30ec0de932) (13 Sept, Hoenggerberg)
   - Emma Hodcroft at [ESCV](https://escv2024.org/) (18-21 Sept, Frankfurt)
   - Chaoran Chen at 2024 [ASM NGS](https://asm.org/events/asm-ngs/home) (13-16 Oct, Washington DC)

--- a/monorepo/website/src/pages/news/2024-09-13-two-weeks.mdx
+++ b/monorepo/website/src/pages/news/2024-09-13-two-weeks.mdx
@@ -1,0 +1,45 @@
+---
+layout: ../../layouts/MdLayout.astro
+title: "Two Weeks of Pathoplexus"
+---
+
+<div>
+    <a href="/news">News</a> > <b>Two Weeks of Pathoplexus</b>
+</div>
+
+# Two Weeks of Pathoplexus
+
+*By the Pathoplexus Team - 13 September 2024*
+
+Since Pathoplexus launched on 27 August, we’ve been humbled by the incredibly positive reaction from the pathogen research, bioinformatics, and public health communities. And it’s been a busy two weeks! We’re thrilled so many people have taken the time to explore the website
+ & [Github](https://github.com/pathoplexus/pathoplexus), read about our aims & commitments, and also helped spread the word about Pathoplexus!
+
+Here’s a short list of updates from our side, to celebrate two weeks of being live!
+
+### In the media:
+- [Science Magazine’s Jon Cohen covered Pathoplexus](https://www.science.org/content/article/new-scientist-run-virus-database-vows-be-transparently-run-and-simple-use), getting some reactions from the community, and a deep-dive to answer some common questions (29 Aug 2024)
+- [UniVadis’ Roberta Villa gave some history on pathogen data sharing](https://www.univadis.it/index.php/viewarticle/si-dice-villa-genomi-virali-nuova-piattaforma-garantire-2024a1000fx1) and how Pathoplexus might fit into the landscape (Italian, 3 Sept 2024)
+- [BBC World Service’s Roland Pease spoke with Emma Hodcroft on Science in Action](https://www.bbc.co.uk/sounds/play/w3ct5vd7) to find out more about Pathoplexus and what it aims to do (4 Sept 2024)
+- [Nature’s Smriti Mallapaty spoke to scientists around the world about Pathoplexus](https://www.nature.com/articles/d41586-024-02864-x) and how it could help build trust in data sharing (9 Sept 2024)
+
+### Visitors:
+- Since launch, Pathoplexus has had thousands of unique visitors from over 100 countries, with 65 creating accounts (necessary to upload, but not to view data)
+
+### Executive Board update:
+- See a list of the most [recent resolutions passed by the Pathoplexus Executive Board](https://pathoplexus.org/about/governance/minutes/2024-09-12_EB_Resolutions.pdf)
+
+### Scientific Advisory Board:
+- We’re incredibly pleased to welcome Pardis Sabeti from the Broad Institute, Harvard University, and HHMI to the [Scientific Advisory Board](https://pathoplexus.org/about/sab)!
+
+### Software updates:
+- Our code is open-source and on [GitHub](http://github.com/pathoplexus). Thank you to everyone from the community who have made suggestions for improvements to [Loculus](https://github.com/loculus-project/loculus/issues) (the software behind Pathoplexus). Since launch, we’ve added a few features and fixed some bugs. All enhancements and bug-fixes are documented on GitHub. Severe incidents with high impact will also be reported on this news page.
+
+### Past talks:
+- Cornelius Roemer and Fabian Engelniederhammer gave a talk on Loculus at "TNG Big Techday 24," which you can [watch on Youtube](https://www.youtube.com/watch?v=wPtwH4siQyU)
+
+### Upcoming talks:
+- Now that we’ve launched, we’re keen to tell you more about Pathoplexus and Loculus! Look out for talks from our members at upcoming conferences:
+  - Tanja Stadler at [SIBE](https://www.sibe-iseb.it/napoli2024) (8-11 Sept, Napoli)
+  - Tanja Stadler at [Inauguration of Alps Infrastructure](https://www.cscs.ch/events/upcoming-events/event-detail?tx_cscsevents_pi1%5Bcontroller%5D=Event&tx_cscsevents_pi1%5Bevent%5D=195&cHash=423f54c401a3f3f71b363a30ec0de932) (13 Sept, Hoenggerberg)
+  - Emma Hodcroft at [ESCV](https://escv2024.org/) (18-21 Sept, Frankfurt)
+  - Chaoran Chen at 2024 [ASM NGS](https://asm.org/events/asm-ngs/home) (13-16 Oct, Washington DC)

--- a/monorepo/website/src/pages/news/2024-09-13-two-weeks.mdx
+++ b/monorepo/website/src/pages/news/2024-09-13-two-weeks.mdx
@@ -19,7 +19,7 @@ Here’s a short list of updates from our side, to celebrate two weeks of being 
 ### In the media:
 - [Science Magazine’s Jon Cohen covered Pathoplexus](https://www.science.org/content/article/new-scientist-run-virus-database-vows-be-transparently-run-and-simple-use), getting some reactions from the community, and a deep-dive to answer some common questions (29 Aug 2024)
 - [UniVadis’ Roberta Villa gave some history on pathogen data sharing](https://www.univadis.it/index.php/viewarticle/si-dice-villa-genomi-virali-nuova-piattaforma-garantire-2024a1000fx1) and how Pathoplexus might fit into the landscape (Italian, 3 Sept 2024)
-- [BBC World Service’s Roland Pease spoke with Emma Hodcroft on Science in Action](https://www.bbc.co.uk/sounds/play/w3ct5vd7) to find out more about Pathoplexus and what it aims to do (4 Sept 2024)
+- [BBC World Service’s Roland Pease spoke with Emma Hodcroft on Science in Action](https://www.bbc.co.uk/sounds/play/w3ct5vd7) (starting at 8m30s) to find out more about Pathoplexus and what it aims to do (4 Sept 2024)
 - [Nature’s Smriti Mallapaty spoke to scientists around the world about Pathoplexus](https://www.nature.com/articles/d41586-024-02864-x) and how it could help build trust in data sharing (9 Sept 2024)
 
 ### Visitors:

--- a/monorepo/website/src/pages/news/2024-09-13-two-weeks.mdx
+++ b/monorepo/website/src/pages/news/2024-09-13-two-weeks.mdx
@@ -12,7 +12,7 @@ title: "Two Weeks of Pathoplexus"
 *By the Pathoplexus Team - 13 September 2024*
 
 Since Pathoplexus launched on 27 August, we’ve been humbled by the incredibly positive reaction from the pathogen research, bioinformatics, and public health communities. And it’s been a busy two weeks! We’re thrilled so many people have taken the time to explore the website
- & [Github](https://github.com/pathoplexus/pathoplexus), read about our aims & commitments, and also helped spread the word about Pathoplexus!
+ & [GitHub](https://github.com/pathoplexus/pathoplexus), read about our aims & commitments, and also helped spread the word about Pathoplexus!
 
 Here’s a short list of updates from our side, to celebrate two weeks of being live!
 

--- a/monorepo/website/src/pages/news/index.astro
+++ b/monorepo/website/src/pages/news/index.astro
@@ -6,6 +6,18 @@ import MdLayout from '../../layouts/MdLayout.astro';
     <h1>News</h1>
     <div class='mt-8'>
         <h2>
+            <a href='/news/2024-09-13-two-weeks'>Two Weeks of Pathoplexus</a>
+        </h2>
+        <div class='italic mb-4'>By the Pathoplexus Team - 13 September 2024</div>
+        <div>
+            Since Pathoplexus launched on 27 August, we’ve been humbled by the incredibly positive reaction from
+             the pathogen research, bioinformatics, and public health communities. And it’s been a busy two weeks! 
+             We’re thrilled so many people have taken the time to explore the website… 
+             <a href='/news/2024-09-12-two-weeks'>Read more</a>
+        </div>
+    </div>
+    <div class='mt-8'>
+        <h2>
             <a href='/news/2024-08-27-hello-world'>Introducing Pathoplexus</a>
         </h2>
         <div class='italic mb-4'>By the Pathoplexus Team - 27 August 2024</div>


### PR DESCRIPTION
News item for 13 Sept 2024 - should go live soon if possible.

Took some liberty in spacing and adding headings to make it look nice. Hopefully preview will work.

EB resolutions link won't work until new push to website goes through. This and the newsitem can hopefully be done together.

https://preview-news-item-sept.pathoplexus.org/news/2024-09-13-two-weeks