### PR TITLE
feat: add broken-link-checker gh action and fix broken links

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
     inputs:
       custom_subdomain:
-        description: 'Custom subdomain for link checking'
+        description: 'Custom subdomain for link checking, e.g. preview-main. By default checks main, preview, staging, and demo.'
         required: false
         type: string
   push:
@@ -14,51 +14,43 @@ on:
   schedule:
     - cron: '9 9 * * *'
 jobs:
-  check-preview-label:
-    runs-on: ubuntu-latest
-    outputs:
-      has-preview-label: ${{ steps.check-label.outputs.has-preview-label }}
-    steps:
-      - name: Check for preview label
-        id: check-label
-        if: github.event_name == 'pull_request'
-        run: |
-          if [[ ${{ contains(github.event.pull_request.labels.*.name, 'preview') }} == 'true' ]]; then
-            echo "has-preview-label=true" >> $GITHUB_OUTPUT
-          else
-            echo "has-preview-label=false" >> $GITHUB_OUTPUT
-          fi
   generate-matrix:
     runs-on: ubuntu-latest
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
+      run_check: ${{ steps.set-matrix.outputs.run_check }}
     steps:
-      - name: Set matrix
+      - name: Set matrix and check conditions
         id: set-matrix
         run: |
           if [[ "${{ github.event_name }}" == "schedule" ]]; then
             echo "matrix={\"subdomain\":[\"preview-main\",\"preview-staging\",\"preview-demo\",\"\"]}" >> $GITHUB_OUTPUT
+            echo "run_check=true" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.custom_subdomain }}" ]]; then
             echo "matrix={\"subdomain\":[\"${{ github.event.inputs.custom_subdomain }}\"]}" >> $GITHUB_OUTPUT
+            echo "run_check=true" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == "push" ]]; then
             echo "matrix={\"subdomain\":[\"preview-${{ github.ref_name }}\"]}" >> $GITHUB_OUTPUT
+            echo "run_check=true" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
             echo "matrix={\"subdomain\":[\"preview-${{ github.head_ref }}\"]}" >> $GITHUB_OUTPUT
+            if [[ ${{ contains(github.event.pull_request.labels.*.name, 'preview') }} == 'true' ]]; then
+              echo "run_check=true" >> $GITHUB_OUTPUT
+            else
+              echo "run_check=false" >> $GITHUB_OUTPUT
+            fi
           else
             echo "matrix={\"subdomain\":[\"\"]}" >> $GITHUB_OUTPUT
+            echo "run_check=true" >> $GITHUB_OUTPUT
           fi
   broken-link-checker:
-    needs: [check-preview-label, generate-matrix]
-    if: >
-      github.event_name != 'pull_request' || (github.event_name == 'pull_request' && needs.check-preview-label.outputs.has-preview-label == 'true')
-
+    needs: generate-matrix
+    if: needs.generate-matrix.outputs.run_check == 'true'
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v4
       - name: Set URL
         id: set-url
         run: |
@@ -67,8 +59,9 @@ jobs:
           else
             echo "url=https://${{ matrix.subdomain }}.pathoplexus.org" >> $GITHUB_OUTPUT
           fi
-      - name: Check broken links
+      - name: Check broken links using muffet
         uses: ruzickap/action-my-broken-link-checker@v2
         with:
           url: ${{ steps.set-url.outputs.url }}
-          cmd_params: '--buffer-size=8192 --max-connections=10 --color=always --header="User-Agent:curl/7.54.0" --timeout=20'
+          # see https://github.com/raviqqe/muffet for details
+          cmd_params: '--buffer-size=8192 --max-connections=10 --color=always --accepted-status-codes="200..300,403,429" --rate-limit=20 --timeout=20'

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -43,6 +43,11 @@ jobs:
             echo "matrix={\"subdomain\":[\"\"]}" >> $GITHUB_OUTPUT
             echo "run_check=true" >> $GITHUB_OUTPUT
           fi
+      - name: Wait for 180 seconds if triggered by push or pull request
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        run: |
+          echo "Waiting for 180 seconds to allow preview to be up..."
+          sleep 180
   broken-link-checker:
     needs: generate-matrix
     if: needs.generate-matrix.outputs.run_check == 'true'
@@ -59,11 +64,6 @@ jobs:
           else
             echo "url=https://${{ matrix.subdomain }}.pathoplexus.org" >> $GITHUB_OUTPUT
           fi
-      - name: Wait for 180 seconds if triggered by push or pull request
-        if: github.event_name == 'push' || github.event_name == 'pull_request'
-        run: |
-          echo "Waiting for 180 seconds to allow preview to be up..."
-          sleep 180
       - name: Check broken links using muffet
         uses: ruzickap/action-my-broken-link-checker@v2
         with:

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -11,7 +11,6 @@ on:
   push:
     branches:
       - main
-      - broken-link-action
   schedule:
     - cron: '9 9 * * *'
 jobs:
@@ -29,26 +28,44 @@ jobs:
           else
             echo "has-preview-label=false" >> $GITHUB_OUTPUT
           fi
+  generate-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Set matrix
+        id: set-matrix
+        run: |
+          if [[ "${{ github.event_name }}" == "schedule" ]]; then
+            echo "matrix={\"subdomain\":[\"preview-main\",\"preview-staging\",\"preview-demo\",\"\"]}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.custom_subdomain }}" ]]; then
+            echo "matrix={\"subdomain\":[\"${{ github.event.inputs.custom_subdomain }}\"]}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            echo "matrix={\"subdomain\":[\"preview-${{ github.ref_name }}\"]}" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "matrix={\"subdomain\":[\"preview-${{ github.head_ref }}\"]}" >> $GITHUB_OUTPUT
+          else
+            echo "matrix={\"subdomain\":[\"\"]}" >> $GITHUB_OUTPUT
+          fi
   broken-link-checker:
-    needs: check-preview-label
+    needs: [check-preview-label, generate-matrix]
     if: >
       github.event_name != 'pull_request' || (github.event_name == 'pull_request' && needs.check-preview-label.outputs.has-preview-label == 'true')
 
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix: ${{fromJson(needs.generate-matrix.outputs.matrix)}}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Set URL
         id: set-url
         run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.custom_subdomain }}" ]]; then
-            echo "url=https://${{ github.event.inputs.custom_subdomain }}.pathoplexus.org" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "push" ]]; then
-            echo "url=https://preview-${GITHUB_REF##*/}.pathoplexus.org" >> $GITHUB_OUTPUT
-          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "url=https://preview-${{ github.head_ref }}.pathoplexus.org" >> $GITHUB_OUTPUT
-          else
+          if [[ -z "${{ matrix.subdomain }}" ]]; then
             echo "url=https://pathoplexus.org" >> $GITHUB_OUTPUT
+          else
+            echo "url=https://${{ matrix.subdomain }}.pathoplexus.org" >> $GITHUB_OUTPUT
           fi
       - name: Check broken links
         uses: ruzickap/action-my-broken-link-checker@v2

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -1,5 +1,7 @@
 name: broken-link-check
 on:
+  pull_request:
+    types: [opened, reopened, labeled, unlabeled, synchronize]
   workflow_dispatch:
     inputs:
       custom_subdomain:
@@ -13,11 +15,28 @@ on:
   schedule:
     - cron: '9 9 * * *'
 jobs:
+  check-preview-label:
+    runs-on: ubuntu-latest
+    outputs:
+      has-preview-label: ${{ steps.check-label.outputs.has-preview-label }}
+    steps:
+      - name: Check for preview label
+        id: check-label
+        if: github.event_name == 'pull_request'
+        run: |
+          if [[ ${{ contains(github.event.pull_request.labels.*.name, 'preview') }} == 'true' ]]; then
+            echo "has-preview-label=true" >> $GITHUB_OUTPUT
+          else
+            echo "has-preview-label=false" >> $GITHUB_OUTPUT
+          fi
   broken-link-checker:
+    needs: check-preview-label
+    if: >
+      github.event_name != 'pull_request' || (github.event_name == 'pull_request' && needs.check-preview-label.outputs.has-preview-label == 'true')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Set URL
         id: set-url
         run: |
@@ -25,6 +44,8 @@ jobs:
             echo "url=https://${{ github.event.inputs.custom_subdomain }}.pathoplexus.org" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == "push" ]]; then
             echo "url=https://preview-${GITHUB_REF##*/}.pathoplexus.org" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            echo "url=https://preview-pr-${{ github.event.pull_request.number }}.pathoplexus.org" >> $GITHUB_OUTPUT
           else
             echo "url=https://pathoplexus.org" >> $GITHUB_OUTPUT
           fi

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -1,0 +1,36 @@
+name: broken-link-check
+on:
+  workflow_dispatch:
+    inputs:
+      custom_subdomain:
+        description: 'Custom subdomain for link checking'
+        required: false
+        type: string
+  push:
+    paths:
+      - .github/workflows/periodic-broken-link-checks.yml
+    branches:
+      - main
+  schedule:
+    - cron: '9 9 * * *'
+jobs:
+  broken-link-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Set URL
+        id: set-url
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ github.event.inputs.custom_subdomain }}" ]]; then
+            echo "url=https://${{ github.event.inputs.custom_subdomain }}.pathoplexus.org" >> $GITHUB_OUTPUT
+          elif [[ "${{ github.event_name }}" == "push" ]]; then
+            echo "url=https://preview-${GITHUB_REF##*/}.pathoplexus.org" >> $GITHUB_OUTPUT
+          else
+            echo "url=https://pathoplexus.org" >> $GITHUB_OUTPUT
+          fi
+      - name: Check broken links
+        uses: ruzickap/action-my-broken-link-checker@v2
+        with:
+          url: ${{ steps.set-url.outputs.url }}
+          cmd_params: '--buffer-size=8192 --max-connections=10 --color=always --header="User-Agent:curl/7.54.0" --timeout=20'

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -59,6 +59,11 @@ jobs:
           else
             echo "url=https://${{ matrix.subdomain }}.pathoplexus.org" >> $GITHUB_OUTPUT
           fi
+      - name: Wait for 180 seconds if triggered by push or pull request
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
+        run: |
+          echo "Waiting for 180 seconds to allow preview to be up..."
+          sleep 180
       - name: Check broken links using muffet
         uses: ruzickap/action-my-broken-link-checker@v2
         with:

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -7,10 +7,9 @@ on:
         required: false
         type: string
   push:
-    paths:
-      - .github/workflows/periodic-broken-link-checks.yml
     branches:
       - main
+      - broken-link-action
   schedule:
     - cron: '9 9 * * *'
 jobs:

--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -33,6 +33,7 @@ jobs:
     needs: check-preview-label
     if: >
       github.event_name != 'pull_request' || (github.event_name == 'pull_request' && needs.check-preview-label.outputs.has-preview-label == 'true')
+
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -45,7 +46,7 @@ jobs:
           elif [[ "${{ github.event_name }}" == "push" ]]; then
             echo "url=https://preview-${GITHUB_REF##*/}.pathoplexus.org" >> $GITHUB_OUTPUT
           elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-            echo "url=https://preview-pr-${{ github.event.pull_request.number }}.pathoplexus.org" >> $GITHUB_OUTPUT
+            echo "url=https://preview-${{ github.head_ref }}.pathoplexus.org" >> $GITHUB_OUTPUT
           else
             echo "url=https://pathoplexus.org" >> $GITHUB_OUTPUT
           fi

--- a/monorepo/website/src/pages/about/governance/data-submission.mdx
+++ b/monorepo/website/src/pages/about/governance/data-submission.mdx
@@ -26,7 +26,7 @@ This document is governed by the [Pathoplexus Values](/about/governance/values) 
 As used in Database Terms of Service, the following terms shall have the following meanings:
 
 <div class="indent"><div class="indent">
-1.1 The term “User” shall mean everyone who accesses the web service (www.pathoplexus.org) in any form
+1.1 The term “User” shall mean everyone who accesses the web service (https://pathoplexus.org) in any form
 
 1.2 The term “Submitter shall mean those who submit data to Pathoplexus 
 

--- a/monorepo/website/src/pages/about/governance/minutes.mdx
+++ b/monorepo/website/src/pages/about/governance/minutes.mdx
@@ -10,7 +10,7 @@ We make summaries of our Member meetings (General Assembly) and Executive Board 
 
 # General Assembly Meetings
 
-- [2024-08-12 Founding Meeting](/about/governance/minutes/2024-08-12_GAmeeting.pdf)
+- [2024-08-12 Founding Meeting](/about/governance/minutes/2024-08-12_PathoplexusGAmeeting.pdf)
 
 
 # Executive Board Meetings

--- a/monorepo/website/src/pages/about/terms-of-use/data-use-terms.mdx
+++ b/monorepo/website/src/pages/about/terms-of-use/data-use-terms.mdx
@@ -37,7 +37,7 @@ Pathoplexus aims to encourage data sharing by providing multiple options for seq
 As used in Data Use Terms, the following terms shall have the following meanings:
 
 <div class="indent"><div class="indent">
-1.1 The term “User” shall mean everyone who accesses the web service (www.pathoplexus.org) in any form
+1.1 The term “User” shall mean everyone who accesses the web service (https://pathoplexus.org) in any form
 
 1.2 The term “Submitter shall mean those who submit data to Pathoplexus 
 

--- a/monorepo/website/src/pages/about/terms-of-use/privacy-policy.mdx
+++ b/monorepo/website/src/pages/about/terms-of-use/privacy-policy.mdx
@@ -4,7 +4,7 @@ title: "Privacy Policy"
 order: 5
 ---
 
-We are pleased that you are visiting our website at www.pathoplexus.org and Pathoplexus our genomic sequence database (“Database”). Data protection and data security when using our website and Database are very important to us. We would therefore like to inform you which of your Personal Data we collect when you visit our website and use our Database and for what purposes it is used.
+We are pleased that you are visiting our website at https://pathoplexus.org and Pathoplexus our genomic sequence database (“Database”). Data protection and data security when using our website and Database are very important to us. We would therefore like to inform you which of your Personal Data we collect when you visit our website and use our Database and for what purposes it is used.
 
 ## Who is responsible?
 

--- a/monorepo/website/src/pages/about/terms-of-use/terms-of-service.mdx
+++ b/monorepo/website/src/pages/about/terms-of-use/terms-of-service.mdx
@@ -27,7 +27,7 @@ The aim of Pathoplexus is to enable and encourage rapid sharing of genetic data 
 As used in Database Terms of Service, the following terms shall have the following meanings:
 
 <div class="indent"><div class="indent">
-1.1 The term “User” shall mean everyone who accesses the web service (www.pathoplexus.org) in any form
+1.1 The term “User” shall mean everyone who accesses the web service (https://pathoplexus.org) in any form
 
 1.2 The term “Submitter shall mean those who submit data to Pathoplexus 
 

--- a/monorepo/website/src/pages/news/index.astro
+++ b/monorepo/website/src/pages/news/index.astro
@@ -1,33 +1,34 @@
 ---
 import MdLayout from '../../layouts/MdLayout.astro';
----
 
+// Add new news items here
+const newsItems = [
+    {
+        slug: '2024-09-13-two-weeks',
+        title: 'Two Weeks of Pathoplexus',
+        date: '13 September 2024',
+        excerpt: "Since Pathoplexus launched on 27 August, we've been humbled by the incredibly positive reaction from the pathogen research, bioinformatics, and public health communities. And it's been a busy two weeks! We're thrilled so many people have taken the time to explore the website…"
+    },
+    {
+        slug: '2024-08-27-hello-world',
+        title: 'Introducing Pathoplexus',
+        date: '27 August 2024',
+        excerpt: 'We are announcing <b>Pathoplexus</b>, a specialised genomic database for viruses of public health importance. By combining modern open-source software with transparent governance structures, Pathoplexus fills a niche within the existing genomic sequencing database landscape, aiming to meet requests from both data submitters and users and striving to improve equity…'
+    }
+];
+---
 <MdLayout frontmatter={{ title: 'News' }}>
     <h1>News</h1>
-    <div class='mt-8'>
-        <h2>
-            <a href='/news/2024-09-13-two-weeks'>Two Weeks of Pathoplexus</a>
-        </h2>
-        <div class='italic mb-4'>By the Pathoplexus Team - 13 September 2024</div>
-        <div>
-            Since Pathoplexus launched on 27 August, we’ve been humbled by the incredibly positive reaction from
-             the pathogen research, bioinformatics, and public health communities. And it’s been a busy two weeks! 
-             We’re thrilled so many people have taken the time to explore the website… 
-             <a href='/news/2024-09-12-two-weeks'>Read more</a>
+    {newsItems.map(item => (
+        <div class='mt-8'>
+            <h2>
+                <a href={`/news/${item.slug}`}>{item.title}</a>
+            </h2>
+            <div class='italic mb-4'>By the Pathoplexus Team - {item.date}</div>
+            <div>
+                {item.excerpt}
+                <a href={`/news/${item.slug}`}>Read more</a>
+            </div>
         </div>
-    </div>
-    <div class='mt-8'>
-        <h2>
-            <a href='/news/2024-08-27-hello-world'>Introducing Pathoplexus</a>
-        </h2>
-        <div class='italic mb-4'>By the Pathoplexus Team - 27 August 2024</div>
-        <div>
-            We are announcing <b>Pathoplexus</b>, a specialised genomic database for viruses of public health
-            importance. By combining modern open-source software with transparent governance structures, Pathoplexus
-            fills a niche within the existing genomic sequencing database landscape, aiming to meet requests from both
-            data submitters and users and striving to improve equity… <a href='/news/2024-08-27-hello-world'
-                >Read more</a
-            >
-        </div>
-    </div>
+    ))}
 </MdLayout>


### PR DESCRIPTION
Resolves #136 
Resolves #133 

Uses https://github.com/raviqqe/muffet under the hood.

You can run the checks locally like this:

```
muffet "https://pathoplexus.org/" --buffer-size=8192 --accepted-status-codes="200..300,403,429" --rate-limit=20 --max-connections=10
```

Also refactors the news excerpts page to make the type of broken link bug less likely in future and generally makes that page easier to maintain into the future.