### PR TITLE
Update to approved crossref branch

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 4de75675b18e737f59f00eaa2469d2b5403df111
+loculusVersion: 0cf62d4de18286cf0767710102ab074711912199 # Crossref backup branch head
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
This sets the loculusVersion to the head of the approved crossref PR: https://github.com/loculus-project/loculus/pull/2810

https://preview-crossref-fallback.pathoplexus.org/