### PR TITLE
fix: allow HTML tags in news excerpts

### DIFF
--- a/monorepo/website/src/pages/news/index.astro
+++ b/monorepo/website/src/pages/news/index.astro
@@ -26,7 +26,7 @@ const newsItems = [
             </h2>
             <div class='italic mb-4'>By the Pathoplexus Team - {item.date}</div>
             <div>
-                {item.excerpt}
+                <Fragment set:html={item.excerpt} />
                 <a href={`/news/${item.slug}`}>Read more</a>
             </div>
         </div>


### PR DESCRIPTION
Resolves #149 

https://preview-fix-excerpt-bug.pathoplexus.org/news