### PR TITLE
ci: Remove link checking from pull requests

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -1,7 +1,5 @@
 name: broken-link-check
 on:
-  pull_request:
-    types: [opened, reopened, labeled, unlabeled, synchronize]
   workflow_dispatch:
     inputs:
       custom_subdomain:


### PR DESCRIPTION
This manifests as very flaky at the moment - partly because you just might not have a preview instance - which is a bit distracting. I think we should add this back, but once we're doing it fully within CI.