### PR TITLE
fix: don't ingest continent as geoLocAdmin2

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -413,7 +413,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         generateIndex: true
         autocomplete: true
         header: Sample details
-        ingest: ncbiGeoRegion
       - name: geoLocCity
         displayName: Collection city
         generateIndex: true


### PR DESCRIPTION
This should be released to production together with the author order fix so we only do one version bump
