### PR TITLE
docs: add how-to guide for API submission

### DIFF
--- a/monorepo/website/src/components/InfoBox.astro
+++ b/monorepo/website/src/components/InfoBox.astro
@@ -1,0 +1,10 @@
+---
+import MaterialSymbolsInfoOutline from '~icons/material-symbols/info-outline';
+---
+
+<div class='bg-primary-500 !text-white p-3 my-4 rounded-lg max-w-md mx-auto box text-sm'>
+    <span style={{ fontSize: '1.0rem' }} class='!text-white'>
+        <MaterialSymbolsInfoOutline />
+    </span>
+    <slot />
+</div>

--- a/monorepo/website/src/pages/about/terms-of-use/open-data.mdx
+++ b/monorepo/website/src/pages/about/terms-of-use/open-data.mdx
@@ -4,16 +4,12 @@ title: Open Data Terms of Use
 menuTitle: Open Data Terms of Use (Summary)
 order: 2
 ---
-import MaterialSymbolsInfoOutline from '~icons/material-symbols/info-outline';
+import InfoBox from '../../../components/InfoBox.astro';
 
-<div class="bg-primary-500 !text-white p-3 my-4 rounded-lg max-w-md mx-auto box text-sm">
-
-<span style={{ fontSize: '1.0rem' }} class="!text-white">
-<MaterialSymbolsInfoOutline />
-</span>
-This summary is provided as a general overview of the Open Data Terms of Use, but only the full terms are used to interpret and arbitrate. For the full terms, and guidance, see the
-<a href="/about/terms-of-use/data-use-terms" class="!text-white">Data Use Terms</a> document.
-</div>
+<InfoBox>
+    This summary is provided as a general overview of the Open Data Terms of Use, but only the full terms are used to interpret and arbitrate. For the full terms, and guidance, see the
+    <a href="/about/terms-of-use/data-use-terms" class="!text-white">Data Use Terms</a> document.
+</InfoBox>
 
 # Summary
 Open Data submitted to Pathoplexus is available for use without restrictions, subject to ethical guidelines and proper attribution. In the following, we state the main Data Use Terms for Open Data as a summary.

--- a/monorepo/website/src/pages/about/terms-of-use/restricted-data.mdx
+++ b/monorepo/website/src/pages/about/terms-of-use/restricted-data.mdx
@@ -4,16 +4,12 @@ title: Restricted Data Terms of Use
 menuTitle: Restricted Data Terms of Use (Summary)
 order: 3
 ---
-import MaterialSymbolsInfoOutline from '~icons/material-symbols/info-outline';
+import InfoBox from '../../../components/InfoBox.astro';
 
-<div class="bg-primary-500 !text-white p-3 my-4 rounded-lg max-w-md mx-auto box text-sm">
-
-<span style={{ fontSize: '1.0rem' }} class="!text-white">
-<MaterialSymbolsInfoOutline />
-</span>
-This summary is provided as a general guideline to the Restricted Data Terms of Use, but only the full terms are used to interpret, enforce, and arbitrate. For the full terms, and guidance, see the
-<a href="/about/terms-of-use/data-use-terms" class="!text-white">Data Use Terms</a> document.
-</div>
+<InfoBox>
+    This summary is provided as a general guideline to the Restricted Data Terms of Use, but only the full terms are used to interpret, enforce, and arbitrate. For the full terms, and guidance, see the
+    <a href="/about/terms-of-use/data-use-terms" class="!text-white">Data Use Terms</a> document.
+</InfoBox>
 
 # Summary
 Restricted Data on Pathoplexus is subject to specific use conditions for a limited time period, up to one year after submission. Afterwards the data automatically becomes Open Data. In the following, we state the main Data Use terms for Restricted Data as a summary.

--- a/monorepo/website/src/pages/docs/how-to/approve-submissions.mdx
+++ b/monorepo/website/src/pages/docs/how-to/approve-submissions.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/DocLayout.astro
 title: 'Approving submissions'
 order: 9
 ---
+import InfoBox from '../../../components/InfoBox.astro';
 
 Once you've uploaded sequences via the website or [API](/api-documentation), you will have to approve them before they are fully submitted.
 
@@ -46,7 +47,9 @@ You can also always view your released sequences by going to 'Browse' in the top
 
 # API
 
-*To use the [demo instance](https://demo.pathoplexus.org) instead of the main instance, please replace `backend.pathoplexus.org` with `backend-demo.pathoplexus.org`.*
+<InfoBox>
+    To use the [demo instance](https://demo.pathoplexus.org) instead of the main instance, please replace `backend.pathoplexus.org` with `backend-demo.pathoplexus.org`.
+</InfoBox>
 
 The following API requests all require an authentication token. Please read [Authenticating via API guide](/docs/how-to/authentication-api) for the instructions to obtain the token an include the token in the HTTP header `Authorization: Bearer <authentication token>`.
 

--- a/monorepo/website/src/pages/docs/how-to/approve-submissions.mdx
+++ b/monorepo/website/src/pages/docs/how-to/approve-submissions.mdx
@@ -48,7 +48,13 @@ You can also always view your released sequences by going to 'Browse' in the top
 
 The following API requests all require an authentication token. Please read [Authenticating via API guide](/docs/how-to/authentication-api) for the instructions to obtain the token an include the token in the HTTP header `Authorization: Bearer <authentication token>`.
 
-You can retrieve a list of uploaded but not released sequences by sending a GET request to the endpoint `https://backend.pathoplexus.org/<organism>/get-sequences?groupIdsFilter=<group id>&statusesFilter=RECEIVED&statusesFilter=IN_PROCESSING&statusesFilter=HAS_ERRORS&statusesFilter=AWAITING_APPROVAL&warningsFilter=INCLUDE_WARNINGS` where the available values for the organism are: `cchf`, `ebola-sudan`, `ebola-zaire` and `west-nile`. The `sequenceEntries` field of the returned object contains a list of sequences with their corresponding `status`:
+You can retrieve a list of uploaded but not released sequences by sending a GET request to the endpoint:
+
+```
+https://backend.pathoplexus.org/<organism>/get-sequences?groupIdsFilter=<group id>&statusesFilter=RECEIVED&statusesFilter=IN_PROCESSING&statusesFilter=HAS_ERRORS&statusesFilter=AWAITING_APPROVAL&warningsFilter=INCLUDE_WARNINGS
+```
+
+The available values for the organism are: `cchf`, `ebola-sudan`, `ebola-zaire` and `west-nile`. The `sequenceEntries` field of the returned object contains a list of sequences with their corresponding `status`:
 
 - Sequence that are in the status `RECEIVED` have not yet been processed. This should usually happen within a few minutes.
 - Sequences that are in the status `IN_PROCESSING` are currently being processed, please wait a few more moments.
@@ -59,7 +65,7 @@ A cURL request could be:
 
 ```
 curl -X 'GET' \
-  'https://backend.pathoplexus.org/<organism>/get-sequences?groupIdsFilter=<grou id>&statusesFilter=RECEIVED&statusesFilter=IN_PROCESSING&statusesFilter=HAS_ERRORS&statusesFilter=AWAITING_APPROVAL&warningsFilter=INCLUDE_WARNINGS' \
+  'https://backend.pathoplexus.org/<organism>/get-sequences?groupIdsFilter=<group id>&statusesFilter=RECEIVED&statusesFilter=IN_PROCESSING&statusesFilter=HAS_ERRORS&statusesFilter=AWAITING_APPROVAL&warningsFilter=INCLUDE_WARNINGS' \
   -H 'accept: application/json' \
   -H 'Authorization: Bearer <authentication token>'
 ```

--- a/monorepo/website/src/pages/docs/how-to/approve-submissions.mdx
+++ b/monorepo/website/src/pages/docs/how-to/approve-submissions.mdx
@@ -46,6 +46,8 @@ You can also always view your released sequences by going to 'Browse' in the top
 
 # API
 
+*To use the [demo instance](https://demo.pathoplexus.org) instead of the main instance, please replace `backend.pathoplexus.org` with `backend-demo.pathoplexus.org`.*
+
 The following API requests all require an authentication token. Please read [Authenticating via API guide](/docs/how-to/authentication-api) for the instructions to obtain the token an include the token in the HTTP header `Authorization: Bearer <authentication token>`.
 
 You can retrieve a list of uploaded but not released sequences by sending a GET request to the endpoint:

--- a/monorepo/website/src/pages/docs/how-to/approve-submissions.mdx
+++ b/monorepo/website/src/pages/docs/how-to/approve-submissions.mdx
@@ -77,7 +77,8 @@ You can either approve selected sequences or approve all sequences that are in t
   "scope": "ALL"
 }
 
-To approve everything:
+// Or to approve all entries without errors (which may include sequences with warnings):
+
 {
   "groupIdsFilter": [<group id>],
   "scope": "ALL"

--- a/monorepo/website/src/pages/docs/how-to/approve-submissions.mdx
+++ b/monorepo/website/src/pages/docs/how-to/approve-submissions.mdx
@@ -46,4 +46,56 @@ You can also always view your released sequences by going to 'Browse' in the top
 
 # API
 
-_Instructions coming soon. See the [Swagger API documentation](/api-documentation)_
+The following API requests all require an authentication token. Please read [Authenticating via API guide](/docs/how-to/authentication-api) for the instructions to obtain the token an include the token in the HTTP header `Authorization: Bearer <authentication token>`.
+
+You can retrieve a list of uploaded but not released sequences by sending a GET request to the endpoint `https://backend.pathoplexus.org/<organism>/get-sequences?groupIdsFilter=<group id>&statusesFilter=RECEIVED&statusesFilter=IN_PROCESSING&statusesFilter=HAS_ERRORS&statusesFilter=AWAITING_APPROVAL&warningsFilter=INCLUDE_WARNINGS` where the available values for the organism are: `cchf`, `ebola-sudan`, `ebola-zaire` and `west-nile`. The `sequenceEntries` field of the returned object contains a list of sequences with their corresponding `status`:
+
+- Sequence that are in the status `RECEIVED` have not yet been processed. This should usually happen within a few minutes.
+- Sequences that are in the status `IN_PROCESSING` are currently being processed, please wait a few more moments.
+- Sequences that are in the status `HAS_ERRORS` contain errors. To find out details, we recommend going to the review page on the website: you can find it by going to the Submission Portal and clicking on "Review".
+- Sequences that are in the status `AWAITING_APPROVAL` have passed the processing and quality checks and can be approved.
+
+A cURL request could be:
+
+```
+curl -X 'GET' \
+  'https://backend.pathoplexus.org/<organism>/get-sequences?groupIdsFilter=<grou id>&statusesFilter=RECEIVED&statusesFilter=IN_PROCESSING&statusesFilter=HAS_ERRORS&statusesFilter=AWAITING_APPROVAL&warningsFilter=INCLUDE_WARNINGS' \
+  -H 'accept: application/json' \
+  -H 'Authorization: Bearer <authentication token>'
+```
+
+You can either approve selected sequences or approve all sequences that are in the status `AWAITING_APPROVAL`. To do that, send a POST request to `https://backend.pathoplexus.org/<organism>/approve-processed-data` with the following request body:
+
+```
+// For a specific list of sequences:
+{
+  "accessionVersionsFilter": [
+    { "accession": "<accession>", "version": <version> },
+    …
+  ],
+  "groupIdsFilter": [<group id>],
+  "scope": "ALL"
+}
+
+To approve everything:
+{
+  "groupIdsFilter": [<group id>],
+  "scope": "ALL"
+}
+```
+
+A cURL request could be:
+
+```
+curl -X 'POST' \
+  'https://backend.pathoplexus.org/<organism>/approve-processed-data' \
+  -H 'accept: application/json' \
+  -H 'Authorization: Bearer <authentication token>' \
+  -H 'Content-Type: application/json' \
+  -d '{
+  "groupIdsFilter": [<group id>],
+  "scope": "ALL"
+}'
+```
+
+Further information can be found in our [Swagger API documentation](https://backend.pathoplexus.org/swagger-ui/index.html#/submission-controller).

--- a/monorepo/website/src/pages/docs/how-to/approve-submissions.mdx
+++ b/monorepo/website/src/pages/docs/how-to/approve-submissions.mdx
@@ -48,7 +48,7 @@ You can also always view your released sequences by going to 'Browse' in the top
 # API
 
 <InfoBox>
-    To use the [demo instance](https://demo.pathoplexus.org) instead of the main instance, please replace `backend.pathoplexus.org` with `backend-demo.pathoplexus.org`.
+    To use the <a href="https://demo.pathoplexus.org" class="!text-white">demo instance</a> instead of the main instance, please replace `backend.pathoplexus.org` with `backend-demo.pathoplexus.org`.
 </InfoBox>
 
 The following API requests all require an authentication token. Please read [Authenticating via API guide](/docs/how-to/authentication-api) for the instructions to obtain the token an include the token in the HTTP header `Authorization: Bearer <authentication token>`.

--- a/monorepo/website/src/pages/docs/how-to/authentication-api.mdx
+++ b/monorepo/website/src/pages/docs/how-to/authentication-api.mdx
@@ -10,7 +10,9 @@ The retrieved token expires after 10 hours.
 
 ## Send request with cURL
 
-The following script demonstrates how you can retrieve a token with a POST request using cURL. It only works if you use a simple username-password authentication. If you only use ORCiD for authentication and do not have a password, you need to add a password (see how to [edit your account](edit-account)). This solution also does not work if you activated two-factor authentication. In these cases, you can retrieve a token from the browser (see section below).
+*To use the [demo instance](https://demo.pathoplexus.org) instead of the main instance, please replace `authentication.pathoplexus.org` with `authentication-demo.pathoplexus.org`.*
+
+The following script demonstrates how you can retrieve a token with a POST request using cURL. It only works if you use a simple username-password authentication. If you only use ORCiD for authentication and do not have a password, you need to add a password (see how to [edit your account](/docs/how-to/edit-account)). This solution also does not work if you activated two-factor authentication. In these cases, you can retrieve a token from the browser (see section below).
 
 ```bash
 KEYCLOAK_TOKEN_URL="https://authentication.pathoplexus.org/realms/loculus/protocol/openid-connect/token"
@@ -27,4 +29,4 @@ echo "$jwt"
 
 ## Retrieve token from browser
 
-After you have logged in on [pathoplexus.org](https://pathoplexus.org), an access token is stored in your browser as a cookie. The token is called `access_token` and you can manually retrieve it from the browser. Instructions on how to do it can be found in the documentation of the browsers: [Google Chrome](https://developer.chrome.com/docs/devtools/application/cookies), [Firefox](https://firefox-source-docs.mozilla.org/devtools-user/storage_inspector/index.html) and [Safari](https://www.cookieserve.com/knowledge-base/website-cookies/how-do-i-check-cookies-in-safari/).
+After you have logged in on [pathoplexus.org](https://pathoplexus.org) (or [demo.pathoplexus.org](https://demo.pathoplexus.org) for the demo instance), an access token is stored in your browser as a cookie. The token is called `access_token` and you can manually retrieve it from the browser. Instructions on how to do it can be found in the documentation of the browsers: [Google Chrome](https://developer.chrome.com/docs/devtools/application/cookies), [Firefox](https://firefox-source-docs.mozilla.org/devtools-user/storage_inspector/index.html) and [Safari](https://www.cookieserve.com/knowledge-base/website-cookies/how-do-i-check-cookies-in-safari/).

--- a/monorepo/website/src/pages/docs/how-to/authentication-api.mdx
+++ b/monorepo/website/src/pages/docs/how-to/authentication-api.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/DocLayout.astro
 title: "Authenticating via API"
 order: 14
 ---
+import InfoBox from '../../../components/InfoBox.astro';
 
 Some of our endpoints require authentication in order to use them. In order to use these endpoints you need to get a JSON web token. You can obtain the token either by sending a request to our Keycloak authentication server or by retrieving the corresponding cookie from the browser.
 
@@ -10,7 +11,9 @@ The retrieved token expires after 10 hours.
 
 ## Send request with cURL
 
-*To use the [demo instance](https://demo.pathoplexus.org) instead of the main instance, please replace `authentication.pathoplexus.org` with `authentication-demo.pathoplexus.org`.*
+<InfoBox>
+    To use the [demo instance](https://demo.pathoplexus.org) instead of the main instance, please replace `authentication.pathoplexus.org` with `authentication-demo.pathoplexus.org`.
+</InfoBox>
 
 The following script demonstrates how you can retrieve a token with a POST request using cURL. It only works if you use a simple username-password authentication. If you only use ORCiD for authentication and do not have a password, you need to add a password (see how to [edit your account](/docs/how-to/edit-account)). This solution also does not work if you activated two-factor authentication. In these cases, you can retrieve a token from the browser (see section below).
 

--- a/monorepo/website/src/pages/docs/how-to/authentication-api.mdx
+++ b/monorepo/website/src/pages/docs/how-to/authentication-api.mdx
@@ -4,7 +4,13 @@ title: "Authenticating via API"
 order: 14
 ---
 
-Some of our endpoints require authentication in order to use them. In order to use these endpoints you need to get a JSON web token. Using curl this would look like:
+Some of our endpoints require authentication in order to use them. In order to use these endpoints you need to get a JSON web token. You can obtain the token either by sending a request to our Keycloak authentication server or by retrieving the corresponding cookie from the browser.
+
+The retrieved token expires after 10 hours.
+
+## Send request with cURL
+
+The following script demonstrates how you can retrieve a token with a POST request using cURL. It only works if you use a simple username-password authentication. If you only use ORCiD for authentication and do not have a password, you need to add a password (see how to [edit your account](edit-account)). This solution also does not work if you activated two-factor authentication. In these cases, you can retrieve a token from the browser (see section below).
 
 ```bash
 KEYCLOAK_TOKEN_URL="https://authentication.pathoplexus.org/realms/loculus/protocol/openid-connect/token"
@@ -18,3 +24,7 @@ jwt=$(echo "$jwt_keycloak" | jq -r '.access_token')
 
 echo "$jwt"
 ```
+
+## Retrieve token from browser
+
+After you have logged in on [pathoplexus.org](https://pathoplexus.org), an access token is stored in your browser as a cookie. The token is called `access_token` and you can manually retrieve it from the browser. Instructions on how to do it can be found in the documentation of the browsers: [Google Chrome](https://developer.chrome.com/docs/devtools/application/cookies), [Firefox](https://firefox-source-docs.mozilla.org/devtools-user/storage_inspector/index.html) and [Safari](https://www.cookieserve.com/knowledge-base/website-cookies/how-do-i-check-cookies-in-safari/).

--- a/monorepo/website/src/pages/docs/how-to/authentication-api.mdx
+++ b/monorepo/website/src/pages/docs/how-to/authentication-api.mdx
@@ -12,7 +12,7 @@ The retrieved token expires after 10 hours.
 ## Send request with cURL
 
 <InfoBox>
-    To use the [demo instance](https://demo.pathoplexus.org) instead of the main instance, please replace `authentication.pathoplexus.org` with `authentication-demo.pathoplexus.org`.
+    To use the <a href="https://demo.pathoplexus.org" class="!text-white">demo instance</a> instead of the main instance, please replace `authentication.pathoplexus.org` with `authentication-demo.pathoplexus.org`.
 </InfoBox>
 
 The following script demonstrates how you can retrieve a token with a POST request using cURL. It only works if you use a simple username-password authentication. If you only use ORCiD for authentication and do not have a password, you need to add a password (see how to [edit your account](/docs/how-to/edit-account)). This solution also does not work if you activated two-factor authentication. In these cases, you can retrieve a token from the browser (see section below).

--- a/monorepo/website/src/pages/docs/how-to/edit-account.mdx
+++ b/monorepo/website/src/pages/docs/how-to/edit-account.mdx
@@ -7,8 +7,9 @@ order: 6
 You can edit your account to update your information anytime.
 Once logged in, you can click on 'My account' in the top-right of the webpage
 
-1. Click 'Edit email address or password' *(We should edit this button)*
+1. Click 'Edit email address or password'
 2. This will redirect you to Keycloak, the component of our website that handles accounts and authentication
-3. From here, you can edit your personal information, such as username, email and name. At the moment, you cannot edit your ORCiD or affiliation/university
-4. Be sure to save any changes after you make them.
-5. You can also explore your login options such as 2-factor authentication, and see where else you're logged in and what other accounts are linked
+3. From here, you can edit your personal information, such as username, email, name, and password. At the moment, you cannot edit your ORCiD or affiliation/university
+4. If you have signed up through ORCiD and do not have a password, you can set a password.
+5. Be sure to save any changes after you make them.
+6. You can also explore your login options such as 2-factor authentication, and see where else you're logged in and what other accounts are linked.

--- a/monorepo/website/src/pages/docs/how-to/upload-sequences.mdx
+++ b/monorepo/website/src/pages/docs/how-to/upload-sequences.mdx
@@ -15,6 +15,8 @@ Loculus expects:
 
 ![Metadata template.](../../../images/MetadataTemplate.png)
 
+The files can also be compressed, accepted formats are .zst, .gz, .zip and .xz.
+
 _You can try out uploading sequences to our [Demo Instance](https://demo.pathoplexus.org/) - it works just like the 'real' Pathoplexus, but is wiped regularly and **no data is sent onward to INSDC**. We also have some [example data](https://pathoplexus.github.io/example_data/) you can upload to the Demo Instance._
 
 
@@ -34,27 +36,37 @@ Uploading sequences via the website is a very way to submit sequences without ha
 
 The data will now be processed, and you will have to approve your submission before it is finalized. You can see how to do this [here](approve-submissions).
 
-<br></br>
-_Detailed API instructions for submitting sequences will come soon, but you can read our [authentication token how-to](/docs/how-to/authentication-api) and [Swagger API documentation](/api-documentation) if you're an experienced user._
 
-{/* ## API
+## API
 
 **By using our API you agree to our [Data Use Terms](/about/terms-of-use/data-use-terms).**
 
-For full instructions on how to upload sequences via our API, you should read our [Swagger API documentation](/api-documentation).
-Before using our API endpoint, you will need to generate an [authentication token](/docs/how-to/authentication-api).
+It is possible to upload sequences through an HTTP API.
 
-As a brief introduction into using the API, you should be sure you have on-hand:
+1. Retrieve an authentication JSON web token: see the [Authenticating via API guide](/docs/how-to/authentication-api).
+2. Identify the Group ID of your group: you can find it on the page of your group (which can be reached from your [user page](https://pathoplexus.org/user)).
+3. Send a POST request:
+    - To upload sequences with an **open use term**: `https://backend.pathoplexus.org/<organism>/submit?groupId=<   group-id>&dataUseTermsType=OPEN`
+    - To upload sequences with a **restricted use term**: `https://backend.pathoplexus.org/<organism>/submit?groupId=<group-id>&dataUseTermsType=RESTRICTED&restrictedUntil=<restricted-until-date>`
+    - The available values for the organism are: `cchf`, `ebola-sudan`, `ebola-zaire` and `west-nile`.
+    - The restricted-until date must be provided in the ISO format (e.g., 2024-08-27).
+    - The header should contain
+        - `Authorization: Bearer <authentication-token>`
+        - `Content-Type: multipart/form-data`
+    - The request body should contain the FASTA and metadata files with the keys `sequenceFile` and `metadataFile`
 
-- The `fasta` file of sequences you wish to submit
-- Matching metadata file
-- The abbreviation for the organism you're submitted sequences of:
-  - `cchf` (CCHF)
-  - `ebola-sudan` (Ebola Sudan)
-  - `ebola-zaire` (Ebola Zaire)
-  - `west-nile` (West Nile)
-- Your submitting Group ID (click on the group from 'My account' to see this)
-- The Data Use Terms you wish to submit under, `OPEN` or `RESTRICTED`
-  - If `RESTRICTED`, the date until which they are restricted (up to 1 year from today) in format `YYYY-MM-DD`
+With cURL, the corresponding command for sending the POST request can be:
 
-You can then construct your API submission query. */}
+```
+curl -X 'POST' \
+  'https://backend.pathoplexus.org/<organism>/submit?groupId=<group id>&dataUseTermsType=OPEN' \
+  -H 'accept: application/json' \
+  -H 'Authorization: Bearer <authentication token>' \
+  -H 'Content-Type: multipart/form-data' \
+  -F 'metadataFile=@<metadata file name>' \
+  -F 'sequenceFile=@<fasta file name>'
+```
+
+Further information can be found in our [Swagger API documentation](https://backend.pathoplexus.org/swagger-ui/index.html#/submission-controller/submit).
+
+As with the website, data will now be processed, and you will have to approve your submission before it is finalized. You can see how to do this [here](approve-submissions).

--- a/monorepo/website/src/pages/docs/how-to/upload-sequences.mdx
+++ b/monorepo/website/src/pages/docs/how-to/upload-sequences.mdx
@@ -3,6 +3,7 @@ layout: ../../../layouts/DocLayout.astro
 title: "Uploading sequences"
 order: 7
 ---
+import InfoBox from '../../../components/InfoBox.astro';
 
 You can only upload sequences if you have [created an account](create-account) and are part of a [group](create-group).
 
@@ -40,7 +41,9 @@ The data will now be processed, and you will have to approve your submission bef
 
 ## API
 
-*To use the [demo instance](https://demo.pathoplexus.org) instead of the main instance, please replace `backend.pathoplexus.org` with `backend-demo.pathoplexus.org`.*
+<InfoBox>
+    To use the [demo instance](https://demo.pathoplexus.org) instead of the main instance, please replace `backend.pathoplexus.org` with `backend-demo.pathoplexus.org`.
+</InfoBox>
 
 **By using our API you agree to our [Data Use Terms](/about/terms-of-use/data-use-terms).**
 

--- a/monorepo/website/src/pages/docs/how-to/upload-sequences.mdx
+++ b/monorepo/website/src/pages/docs/how-to/upload-sequences.mdx
@@ -40,6 +40,8 @@ The data will now be processed, and you will have to approve your submission bef
 
 ## API
 
+*To use the [demo instance](https://demo.pathoplexus.org) instead of the main instance, please replace `backend.pathoplexus.org` with `backend-demo.pathoplexus.org`.*
+
 **By using our API you agree to our [Data Use Terms](/about/terms-of-use/data-use-terms).**
 
 It is currently possible to upload sequences through an HTTP API. We also plan to release a command-line interface before the end of 2024.

--- a/monorepo/website/src/pages/docs/how-to/upload-sequences.mdx
+++ b/monorepo/website/src/pages/docs/how-to/upload-sequences.mdx
@@ -50,9 +50,9 @@ To upload sequences through the HTTP API you will need to:
 1. Retrieve an authentication JSON web token: see the [Authenticating via API guide](/docs/how-to/authentication-api).
 2. Identify the Group ID of your group: you can find it on the page of your group (which can be reached from your [user page](https://pathoplexus.org/user)).
 3. Send a POST request:
-    - To upload sequences with the **open use terms**: `https://backend.pathoplexus.org/<organism>/submit?groupId=<   group-id>&dataUseTermsType=OPEN`
+    - To upload sequences with the **open use terms**: `https://backend.pathoplexus.org/<organism>/submit?groupId=<   group id>&dataUseTermsType=OPEN`
 
-    - To upload sequences with the **restricted use terms**: `https://backend.pathoplexus.org/<organism>/submit?groupId=<group-id>&dataUseTermsType=RESTRICTED&restrictedUntil=<restricted-until-date>`
+    - To upload sequences with the **restricted use terms**: `https://backend.pathoplexus.org/<organism>/submit?groupId=<group id>&dataUseTermsType=RESTRICTED&restrictedUntil=<restricted-until-date>`
 
     - The available values for the organism are: `cchf`, `ebola-sudan`, `ebola-zaire` and `west-nile`.
     - The restricted-until date must be provided in the ISO format (e.g., 2024-08-27).

--- a/monorepo/website/src/pages/docs/how-to/upload-sequences.mdx
+++ b/monorepo/website/src/pages/docs/how-to/upload-sequences.mdx
@@ -15,7 +15,8 @@ Loculus expects:
 
 ![Metadata template.](../../../images/MetadataTemplate.png)
 
-The files can also be compressed, accepted formats are .zst, .gz, .zip and .xz.
+The files can also be compressed: accepted formats are .zst, .gz, .zip and .xz.
+
 
 _You can try out uploading sequences to our [Demo Instance](https://demo.pathoplexus.org/) - it works just like the 'real' Pathoplexus, but is wiped regularly and **no data is sent onward to INSDC**. We also have some [example data](https://pathoplexus.github.io/example_data/) you can upload to the Demo Instance._
 
@@ -41,19 +42,25 @@ The data will now be processed, and you will have to approve your submission bef
 
 **By using our API you agree to our [Data Use Terms](/about/terms-of-use/data-use-terms).**
 
-It is possible to upload sequences through an HTTP API.
+It is currently possible to upload sequences through an HTTP API. We also plan to release a command-line interface before the end of 2024.
+
+To upload sequences through the HTTP API you will need to:
+
 
 1. Retrieve an authentication JSON web token: see the [Authenticating via API guide](/docs/how-to/authentication-api).
 2. Identify the Group ID of your group: you can find it on the page of your group (which can be reached from your [user page](https://pathoplexus.org/user)).
 3. Send a POST request:
-    - To upload sequences with an **open use term**: `https://backend.pathoplexus.org/<organism>/submit?groupId=<   group-id>&dataUseTermsType=OPEN`
-    - To upload sequences with a **restricted use term**: `https://backend.pathoplexus.org/<organism>/submit?groupId=<group-id>&dataUseTermsType=RESTRICTED&restrictedUntil=<restricted-until-date>`
+    - To upload sequences with the **open use terms**: `https://backend.pathoplexus.org/<organism>/submit?groupId=<   group-id>&dataUseTermsType=OPEN`
+
+    - To upload sequences with the **restricted use terms**: `https://backend.pathoplexus.org/<organism>/submit?groupId=<group-id>&dataUseTermsType=RESTRICTED&restrictedUntil=<restricted-until-date>`
+
     - The available values for the organism are: `cchf`, `ebola-sudan`, `ebola-zaire` and `west-nile`.
     - The restricted-until date must be provided in the ISO format (e.g., 2024-08-27).
     - The header should contain
         - `Authorization: Bearer <authentication-token>`
         - `Content-Type: multipart/form-data`
-    - The request body should contain the FASTA and metadata files with the keys `sequenceFile` and `metadataFile`
+    - The request body should contain the FASTA and metadata TSV files with the keys `sequenceFile` and `metadataFile`
+
 
 With cURL, the corresponding command for sending the POST request can be:
 

--- a/monorepo/website/src/pages/docs/how-to/upload-sequences.mdx
+++ b/monorepo/website/src/pages/docs/how-to/upload-sequences.mdx
@@ -42,7 +42,7 @@ The data will now be processed, and you will have to approve your submission bef
 ## API
 
 <InfoBox>
-    To use the [demo instance](https://demo.pathoplexus.org) instead of the main instance, please replace `backend.pathoplexus.org` with `backend-demo.pathoplexus.org`.
+    To use the <a href="https://demo.pathoplexus.org" class="!text-white">demo instance</a> instead of the main instance, please replace `backend.pathoplexus.org` with `backend-demo.pathoplexus.org`.
 </InfoBox>
 
 **By using our API you agree to our [Data Use Terms](/about/terms-of-use/data-use-terms).**


### PR DESCRIPTION
This adds some very rudimentary docs on how to submit and approve sequences via API.

See https://preview-docs-api-upload.pathoplexus.org/docs/how-to/upload-sequences and https://preview-docs-api-upload.pathoplexus.org/docs/how-to/approve-submissions.

The broken link checker is failing which I think is a bug: #165