### PR TITLE
Change loculus version to cherry pick with reloader removed

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 37f4ab8aeb4913e492c0e4352c17e9f201817f61
+loculusVersion: 14b1fea63f781bc9447233989aa5d102e03a765c
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
Resets staging to current head and cherry pick with reloader removed on https://github.com/loculus-project/loculus/pull/2876. 