### PR TITLE
Add custom github link for pathoplexus

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -4,6 +4,7 @@ registrationTermsMessage: >
 runDevelopmentMainDatabase: true
 bannerMessage: This is a preview instance. Do not rely on this data for real analyses.
 gitHubEditLink: https://github.com/pathoplexus/pathoplexus/edit/main/monorepo/website/
+gitHubMainUrl: https://github.com/pathoplexus/pathoplexus
 runDevelopmentKeycloakDatabase: true
 dataUseTermsUrls:
   open: https://pathoplexus.org/about/terms-of-use/open-data


### PR DESCRIPTION
Relates to https://github.com/loculus-project/loculus/pull/2797

~(preview not needed IMO, this is currently being merged in advance of the loculus bump, which is fine)~

https://preview-custom-github-link.pathoplexus.org/