### PR TITLE
Add gcaAccession

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -486,6 +486,14 @@ defaultOrganismConfig: &defaultOrganismConfig
         header: "INSDC"
         noInput: true
         oneHeader: true
+      - name: gcaAccession
+        displayName: GCA accession
+        customDisplay:
+          type: link
+          url: "https://www.ncbi.nlm.nih.gov/datasets/genome/__value__"
+        header: "INSDC"
+        noInput: true
+        oneHeader: true
       - name: cultureId
         displayName: Culture ID
         header: Sample details


### PR DESCRIPTION
The ena-submission pipeline is failing to upload external metadata because it is uploading a gcaAccession field which is currently not in the config. 

I hope that this will not cause temporary downtime as this field is not submitted by users but we should test on staging first especially as addng latitude and longitude was leading to issues in LAPIS-SILO. 