### PR TITLE
Add gcaAccession

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -679,6 +679,14 @@ defaultOrganismConfig: &defaultOrganismConfig
         definition: "Accession of corresponding public BioSample of the raw reads in the INSDC"
         example: "SAMN12345678"
         oneHeader: true
+      - name: gcaAccession
+        displayName: GCA accession
+        customDisplay:
+          type: link
+          url: "https://www.ncbi.nlm.nih.gov/datasets/genome/__value__"
+        header: "INSDC"
+        noInput: true
+        oneHeader: true
       - name: cultureId
         displayName: Culture ID
         header: Sample details


### PR DESCRIPTION
Update: https://github.com/loculus-project/loculus/pull/3232 fixed the issue that previously blocked up from adding new fields without reprocessing all metadata

Note we will still need to update the external metadata pipeline to upload the gcaAccession to PPX - but we can do that in a later PR

https://preview-add-gca-accession.ppx.bio