### PR TITLE
ci(broken-link-checker): don't check external links to ncbi nuccore, these often time out and we trust the links work

### DIFF
--- a/.github/workflows/broken-link-check.yml
+++ b/.github/workflows/broken-link-check.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           url: ${{ steps.set-url.outputs.url }}
           # see https://github.com/raviqqe/muffet for parameter details
-          cmd_params: --buffer-size=8192 --max-connections=5 --color=always --accepted-status-codes="200..300,403,429" --rate-limit=10 --timeout=500 --ignore-fragments
+          cmd_params: --buffer-size=8192 --exclude="ncbi.nlm.nih.gov/nuccore" --max-connections=5 --color=always --accepted-status-codes="200..300,403,429" --rate-limit=10 --timeout=500 --ignore-fragments
   broken-internal-link-checker:
     needs: generate-matrix
     if: needs.generate-matrix.outputs.run_check == 'true'


### PR DESCRIPTION
related to #152 