### PR TITLE
feat(ci): highlight breaking changes in Loculus bump PRs, allow non-main Loculus target commit, use PAT to trigger website action from auto-PRs

### DIFF
--- a/.github/workflows/bump-main-loculus-version-to-latest.yaml
+++ b/.github/workflows/bump-main-loculus-version-to-latest.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           token: ${{ secrets.PATHOPLEXUS_PUSH_PAT }}
           commit-message: "Update Loculus version to https://github.com/loculus-project/loculus/commit/${{ steps.get_loculus_commit.outputs.LATEST_SHA }}"
-          title: "${{ steps.changelog.outputs.HAS_BREAKING_CHANGES == 'true' && 'Breaking: ' || '' }}Update Loculus version to ${{ steps.get_loculus_commit.outputs.LATEST_SHA_SHORT }}${{ steps.get_loculus_commit.outputs.IS_CUSTOM_TARGET == 'true' && format(' (non-main: {0})', steps.get_loculus_commit.outputs.TARGET_BRANCH) || '' }}"
+          title: "feat(deps): update Loculus version to ${{ steps.get_loculus_commit.outputs.LATEST_SHA_SHORT }}${{ steps.get_loculus_commit.outputs.IS_CUSTOM_TARGET == 'true' && format(' (non-main: {0})', steps.get_loculus_commit.outputs.TARGET_BRANCH) || '' }}"
           # Warning: The PR self approval workflow depends on the exact format
           # of the author name (github.actor) here
           body: |

--- a/.github/workflows/bump-main-loculus-version-to-latest.yaml
+++ b/.github/workflows/bump-main-loculus-version-to-latest.yaml
@@ -6,6 +6,8 @@ on:
         description: 'Target Loculus SHA (leave empty for latest)'
         required: false
         default: ''
+  repository_dispatch:
+    types: [create_preview_pr]
 jobs:
   update-loculus-version:
     runs-on: ubuntu-latest
@@ -19,16 +21,14 @@ jobs:
         run: |
           git clone https://github.com/loculus-project/loculus.git loculus_repo
           cd loculus_repo
-          if [ -n "${{ github.event.inputs.target_sha }}" ]; then
-            git checkout ${{ github.event.inputs.target_sha }}
-          fi
+          git checkout ${{ github.event.inputs.target_sha || github.event.client_payload.target_sha || 'main' }}
           LATEST_SHA=$(git rev-parse HEAD)
           BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
           echo "LATEST_SHA=$LATEST_SHA" >> $GITHUB_OUTPUT
           echo "LATEST_SHA_SHORT=${LATEST_SHA:0:6}" >> $GITHUB_OUTPUT
           echo "BRANCH_NAME=update-loculus-${LATEST_SHA:0:6}" >> $GITHUB_OUTPUT
           echo "TARGET_BRANCH=$BRANCH_NAME" >> $GITHUB_OUTPUT
-          echo "IS_CUSTOM_TARGET=${{ github.event.inputs.target_sha != '' }}" >> $GITHUB_OUTPUT
+          echo "IS_CUSTOM_TARGET=${{ (github.event.inputs.target_sha != '' || github.event.client_payload.target_sha != '') && 'true' || 'false' }}" >> $GITHUB_OUTPUT
       - name: Get current Loculus version
         id: get_current_version
         run: |

--- a/.github/workflows/bump-main-loculus-version-to-latest.yaml
+++ b/.github/workflows/bump-main-loculus-version-to-latest.yaml
@@ -21,9 +21,12 @@ jobs:
             git checkout ${{ github.event.inputs.target_sha }}
           fi
           LATEST_SHA=$(git rev-parse HEAD)
+          BRANCH_NAME=$(git rev-parse --abbrev-ref HEAD)
           echo "LATEST_SHA=$LATEST_SHA" >> $GITHUB_OUTPUT
           echo "LATEST_SHA_SHORT=${LATEST_SHA:0:6}" >> $GITHUB_OUTPUT
           echo "BRANCH_NAME=update-loculus-${LATEST_SHA:0:6}" >> $GITHUB_OUTPUT
+          echo "TARGET_BRANCH=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          echo "IS_CUSTOM_TARGET=${{ github.event.inputs.target_sha != '' }}" >> $GITHUB_OUTPUT
       - name: Get current Loculus version
         id: get_current_version
         run: |
@@ -65,7 +68,7 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update Loculus version to https://github.com/loculus-project/loculus/commit/${{ steps.get_loculus_commit.outputs.LATEST_SHA }}"
-          title: "${{ steps.changelog.outputs.HAS_BREAKING_CHANGES == 'true' && 'Breaking: ' || '' }}Update Loculus version to ${{ steps.get_loculus_commit.outputs.LATEST_SHA_SHORT }}"
+          title: "${{ steps.changelog.outputs.HAS_BREAKING_CHANGES == 'true' && 'Breaking: ' || '' }}Update Loculus version to ${{ steps.get_loculus_commit.outputs.LATEST_SHA_SHORT }}${{ steps.get_loculus_commit.outputs.IS_CUSTOM_TARGET == 'true' && format(' (non-main: {0})', steps.get_loculus_commit.outputs.TARGET_BRANCH) || '' }}"
           # Warning: The PR self approval workflow depends on the exact format
           # of the author name (github.actor) here
           body: |
@@ -80,8 +83,12 @@ jobs:
 
             ### Preview
             https://preview-${{ steps.get_loculus_commit.outputs.BRANCH_NAME }}.pathoplexus.org
+
+            ${{ steps.get_loculus_commit.outputs.IS_CUSTOM_TARGET == 'true' && format('> **Note:** This PR targets a non-main branch: `{0}`', steps.get_loculus_commit.outputs.TARGET_BRANCH) || '' }}
           branch: ${{ steps.get_loculus_commit.outputs.BRANCH_NAME }}
           base: main
           labels: |-
             preview
             ${{ steps.changelog.outputs.HAS_BREAKING_CHANGES == 'true' && 'breaking' || '' }}
+            ${{ steps.get_loculus_commit.outputs.IS_CUSTOM_TARGET == 'true' && 'non-main-target' || '' }}
+          draft: ${{ steps.get_loculus_commit.outputs.IS_CUSTOM_TARGET == 'true' }}

--- a/.github/workflows/bump-main-loculus-version-to-latest.yaml
+++ b/.github/workflows/bump-main-loculus-version-to-latest.yaml
@@ -70,7 +70,7 @@ jobs:
         with:
           token: ${{ secrets.PATHOPLEXUS_PUSH_PAT }}
           commit-message: "Update Loculus version to https://github.com/loculus-project/loculus/commit/${{ steps.get_loculus_commit.outputs.LATEST_SHA }}"
-          title: "feat(deps): update Loculus version to ${{ steps.get_loculus_commit.outputs.LATEST_SHA_SHORT }}${{ steps.get_loculus_commit.outputs.IS_CUSTOM_TARGET == 'true' && format(' (non-main: {0})', steps.get_loculus_commit.outputs.TARGET_BRANCH) || '' }}"
+          title: "Update Loculus version to ${{ steps.get_loculus_commit.outputs.LATEST_SHA_SHORT }}${{ steps.get_loculus_commit.outputs.IS_CUSTOM_TARGET == 'true' && format(' (non-main: {0})', steps.get_loculus_commit.outputs.TARGET_BRANCH) || '' }}"
           # Warning: The PR self approval workflow depends on the exact format
           # of the author name (github.actor) here
           body: |

--- a/.github/workflows/bump-main-loculus-version-to-latest.yaml
+++ b/.github/workflows/bump-main-loculus-version-to-latest.yaml
@@ -1,70 +1,74 @@
 name: Create PR to bump main pathoplexus's Loculus version to latest
 on:
   workflow_dispatch:
+    inputs:
+      target_sha:
+        description: 'Target Loculus SHA (leave empty for latest)'
+        required: false
+        default: ''
 jobs:
   update-loculus-version:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout current repository
         uses: actions/checkout@v4
-
       - name: Clone Loculus repository and get latest SHA
         id: get_loculus_commit
         run: |
           git clone https://github.com/loculus-project/loculus.git loculus_repo
           cd loculus_repo
+          if [ -n "${{ github.event.inputs.target_sha }}" ]; then
+            git checkout ${{ github.event.inputs.target_sha }}
+          fi
           LATEST_SHA=$(git rev-parse HEAD)
           echo "LATEST_SHA=$LATEST_SHA" >> $GITHUB_OUTPUT
           echo "LATEST_SHA_SHORT=${LATEST_SHA:0:6}" >> $GITHUB_OUTPUT
           echo "BRANCH_NAME=update-loculus-${LATEST_SHA:0:6}" >> $GITHUB_OUTPUT
-
       - name: Get current Loculus version
         id: get_current_version
         run: |
           CURRENT_VERSION=$(yq e '.loculusVersion' pathoplexus_app/values.yaml)
           echo "CURRENT_VERSION=$CURRENT_VERSION" >> $GITHUB_OUTPUT
-
       - name: Update values.yaml
         run: |
           yq e -i '.loculusVersion = "${{ steps.get_loculus_commit.outputs.LATEST_SHA }}"' pathoplexus_app/values.yaml
-
-      - name: Generate changelog
+      - name: Generate changelog and detect breaking changes
         id: changelog
         run: |
           cd loculus_repo
-          CHANGELOG=$( \
-            git log --pretty=format:"- %s" \
-            ${{ steps.get_current_version.outputs.CURRENT_VERSION }}..${{ steps.get_loculus_commit.outputs.LATEST_SHA }} \
-            | sed 's/.*#\([0-9]\+\)[^#]*$/- loculus-project\/loculus#\1/'
-          )
+          CHANGELOG=$(git log --pretty=format:"- %s" ${{ steps.get_current_version.outputs.CURRENT_VERSION }}..${{ steps.get_loculus_commit.outputs.LATEST_SHA }} | sed 's/.*#\([0-9]\+\)[^#]*$/- loculus-project\/loculus#\1/')
+          BREAKING_CHANGES=$(echo "$CHANGELOG" | grep -iE '^- (.*!.*|.*breaking.*)' || true)
           echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
-      
+          if [ ! -z "$BREAKING_CHANGES" ]; then
+            echo "HAS_BREAKING_CHANGES=true" >> $GITHUB_OUTPUT
+            echo "BREAKING_CHANGES<<EOF" >> $GITHUB_OUTPUT
+            echo "### 🚨 Breaking Changes" >> $GITHUB_OUTPUT
+            echo "$BREAKING_CHANGES" >> $GITHUB_OUTPUT
+            echo "EOF" >> $GITHUB_OUTPUT
+          else
+            echo "HAS_BREAKING_CHANGES=false" >> $GITHUB_OUTPUT
+          fi
       - name: Remove temporary loculus_repo
-        run: |
-          rm -rf loculus_repo
-      
+        run: rm -rf loculus_repo
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update Loculus version to https://github.com/loculus-project/loculus/commit/${{ steps.get_loculus_commit.outputs.LATEST_SHA }}"
-          title: "Update Loculus version to ${{ steps.get_loculus_commit.outputs.LATEST_SHA_SHORT }}"
-          # Warning: The PR self approval workflow depends on the exact format
-          # of the author name here
+          title: "${{ steps.changelog.outputs.HAS_BREAKING_CHANGES == 'true' && 'Breaking: ' || '' }}Update Loculus version to ${{ steps.get_loculus_commit.outputs.LATEST_SHA_SHORT }}"
           body: |
             @${{ github.actor }} wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/${{ steps.get_current_version.outputs.CURRENT_VERSION }} to https://github.com/loculus-project/loculus/commit/${{ steps.get_loculus_commit.outputs.LATEST_SHA }}.
-
+            ${{ steps.changelog.outputs.BREAKING_CHANGES }}
             ### Changelog
             ${{ steps.changelog.outputs.CHANGELOG }}
-
             ### Comparison
             https://github.com/loculus-project/loculus/compare/${{ steps.get_current_version.outputs.CURRENT_VERSION }}...${{ steps.get_loculus_commit.outputs.LATEST_SHA }}
-
             ### Preview
             https://preview-${{ steps.get_loculus_commit.outputs.BRANCH_NAME }}.pathoplexus.org
-
           branch: ${{ steps.get_loculus_commit.outputs.BRANCH_NAME }}
           base: main
-          labels: preview
+          labels: |-
+            preview
+            ${{ steps.changelog.outputs.HAS_BREAKING_CHANGES == 'true' && 'breaking' || '' }}

--- a/.github/workflows/bump-main-loculus-version-to-latest.yaml
+++ b/.github/workflows/bump-main-loculus-version-to-latest.yaml
@@ -68,7 +68,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v7
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.PATHOPLEXUS_PUSH_PAT }}
           commit-message: "Update Loculus version to https://github.com/loculus-project/loculus/commit/${{ steps.get_loculus_commit.outputs.LATEST_SHA }}"
           title: "${{ steps.changelog.outputs.HAS_BREAKING_CHANGES == 'true' && 'Breaking: ' || '' }}Update Loculus version to ${{ steps.get_loculus_commit.outputs.LATEST_SHA_SHORT }}${{ steps.get_loculus_commit.outputs.IS_CUSTOM_TARGET == 'true' && format(' (non-main: {0})', steps.get_loculus_commit.outputs.TARGET_BRANCH) || '' }}"
           # Warning: The PR self approval workflow depends on the exact format

--- a/.github/workflows/bump-main-loculus-version-to-latest.yaml
+++ b/.github/workflows/bump-main-loculus-version-to-latest.yaml
@@ -12,6 +12,8 @@ jobs:
     steps:
       - name: Checkout current repository
         uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.PATHOPLEXUS_PUSH_PAT }}
       - name: Clone Loculus repository and get latest SHA
         id: get_loculus_commit
         run: |

--- a/.github/workflows/bump-main-loculus-version-to-latest.yaml
+++ b/.github/workflows/bump-main-loculus-version-to-latest.yaml
@@ -36,8 +36,16 @@ jobs:
         id: changelog
         run: |
           cd loculus_repo
-          CHANGELOG=$(git log --pretty=format:"- %s" ${{ steps.get_current_version.outputs.CURRENT_VERSION }}..${{ steps.get_loculus_commit.outputs.LATEST_SHA }} | sed 's/.*#\([0-9]\+\)[^#]*$/- loculus-project\/loculus#\1/')
-          BREAKING_CHANGES=$(echo "$CHANGELOG" | grep -iE '^- (.*!.*|.*breaking.*)' || true)
+          CHANGELOG=$( \
+            git log --pretty=format:"- %s" \
+            ${{ steps.get_current_version.outputs.CURRENT_VERSION }}..${{ steps.get_loculus_commit.outputs.LATEST_SHA }} \
+            | sed 's/.*#\([0-9]\+\)[^#]*$/- loculus-project\/loculus#\1/'
+          )
+          BREAKING_CHANGES=$( \
+            echo "$CHANGELOG" \
+            | grep -iE '^- (.*!.*|.*breaking.*)' \
+            || true
+          )
           echo "CHANGELOG<<EOF" >> $GITHUB_OUTPUT
           echo "$CHANGELOG" >> $GITHUB_OUTPUT
           echo "EOF" >> $GITHUB_OUTPUT
@@ -58,13 +66,18 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: "Update Loculus version to https://github.com/loculus-project/loculus/commit/${{ steps.get_loculus_commit.outputs.LATEST_SHA }}"
           title: "${{ steps.changelog.outputs.HAS_BREAKING_CHANGES == 'true' && 'Breaking: ' || '' }}Update Loculus version to ${{ steps.get_loculus_commit.outputs.LATEST_SHA_SHORT }}"
+          # Warning: The PR self approval workflow depends on the exact format
+          # of the author name (github.actor) here
           body: |
             @${{ github.actor }} wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/${{ steps.get_current_version.outputs.CURRENT_VERSION }} to https://github.com/loculus-project/loculus/commit/${{ steps.get_loculus_commit.outputs.LATEST_SHA }}.
             ${{ steps.changelog.outputs.BREAKING_CHANGES }}
+
             ### Changelog
             ${{ steps.changelog.outputs.CHANGELOG }}
+
             ### Comparison
             https://github.com/loculus-project/loculus/compare/${{ steps.get_current_version.outputs.CURRENT_VERSION }}...${{ steps.get_loculus_commit.outputs.LATEST_SHA }}
+
             ### Preview
             https://preview-${{ steps.get_loculus_commit.outputs.BRANCH_NAME }}.pathoplexus.org
           branch: ${{ steps.get_loculus_commit.outputs.BRANCH_NAME }}


### PR DESCRIPTION
- When commit title includes `!` or `breaking` then:
  - add a section "breaking" to the list of changes
  - add a label "breaking"
  - ~add "breaking" to the PR title~ (removed after feedback by @theosanderson)
- Allow passing a loculus sha/branch name to checkout instead of main, in that case
  - add name of that branch/sha to the PR title
  - add a label to show it's non-main targeting
  it looks like this:
  <img width="797" alt="Brave Browser 2024-10-09 13 28 08" src="https://github.com/user-attachments/assets/e65a0a93-d8b3-49c0-92fb-bc6a3e79a513">
  <img width="1278" alt="image" src="https://github.com/user-attachments/assets/6576c4ef-99b3-4cfa-8080-31e2414aaa0c">
- Using a PAT so that these PRs also trigger website action, see https://stackoverflow.com/a/77447725/7483211 
- Add repository dispatch to "On:" section to allow experimental triggering of this workflow from e.g. loculus actions
  


  