### PR TITLE
Update Loculus version to 9d25a5 (non-main: docs-new-pipeline)

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 188eb04e7cca97619b9d5bd048782d20ac196f55
+loculusVersion: 9d25a5d5c2cebb353a697fccdb3e1dfe88bd0c74
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@corneliusroemer wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/188eb04e7cca97619b9d5bd048782d20ac196f55 to https://github.com/loculus-project/loculus/commit/9d25a5d5c2cebb353a697fccdb3e1dfe88bd0c74.


### Changelog
- docs: document how to deploy a custom pipeline with Kubernetes and Helm
- docs: add reference of Helm chart configuration
- loculus-project/loculus#2975
- loculus-project/loculus#2971
- loculus-project/loculus#2958
- loculus-project/loculus#2969
- loculus-project/loculus#2968

### Comparison
https://github.com/loculus-project/loculus/compare/188eb04e7cca97619b9d5bd048782d20ac196f55...9d25a5d5c2cebb353a697fccdb3e1dfe88bd0c74

### Preview
https://preview-update-loculus-9d25a5.pathoplexus.org

> **Note:** This PR targets a non-main branch: `docs-new-pipeline`