### PR TITLE
Update Loculus version to cc66ee (non-main: ppx-preview)

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 188eb04e7cca97619b9d5bd048782d20ac196f55
+loculusVersion: cc66ee9ef942a9108365c64b4e54563d2becd5b1
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@corneliusroemer wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/188eb04e7cca97619b9d5bd048782d20ac196f55 to https://github.com/loculus-project/loculus/commit/cc66ee9ef942a9108365c64b4e54563d2becd5b1.


### Changelog
- feat(ci): allow creation of ppx preview pr to ease testing
- loculus-project/loculus#2975
- loculus-project/loculus#2971
- loculus-project/loculus#2958
- loculus-project/loculus#2969
- loculus-project/loculus#2968

### Comparison
https://github.com/loculus-project/loculus/compare/188eb04e7cca97619b9d5bd048782d20ac196f55...cc66ee9ef942a9108365c64b4e54563d2becd5b1

### Preview
https://preview-update-loculus-cc66ee.pathoplexus.org

> **Note:** This PR targets a non-main branch: `ppx-preview`