### PR TITLE
Update Loculus version to e96145 (non-main: HEAD)

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 188eb04e7cca97619b9d5bd048782d20ac196f55
+loculusVersion: e961453f8f7eb93c0ecedba680df0d13df5a3e6d
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@corneliusroemer wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/188eb04e7cca97619b9d5bd048782d20ac196f55 to https://github.com/loculus-project/loculus/commit/e961453f8f7eb93c0ecedba680df0d13df5a3e6d.


### Changelog
- Try to use correct payload
- try this instead to use head sha
- woops
- Test empty commit
- feat(ci): allow creation of ppx preview pr to ease testing
- loculus-project/loculus#2975
- loculus-project/loculus#2971
- loculus-project/loculus#2958
- loculus-project/loculus#2969
- loculus-project/loculus#2968

### Comparison
https://github.com/loculus-project/loculus/compare/188eb04e7cca97619b9d5bd048782d20ac196f55...e961453f8f7eb93c0ecedba680df0d13df5a3e6d

### Preview
https://preview-update-loculus-e96145.pathoplexus.org

> **Note:** This PR targets a non-main branch: `HEAD`