### PR TITLE
Update Loculus version to 4f8ebb (non-main: ppx-preview)

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 188eb04e7cca97619b9d5bd048782d20ac196f55
+loculusVersion: 4f8ebb694979e7e4617b0b366c8d8c4ba6c37660
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@corneliusroemer wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/188eb04e7cca97619b9d5bd048782d20ac196f55 to https://github.com/loculus-project/loculus/commit/4f8ebb694979e7e4617b0b366c8d8c4ba6c37660.


### Changelog
- Try to use ref instead of sha for better markup
- Try to use correct payload
- try this instead to use head sha
- woops
- Test empty commit
- feat(ci): allow creation of ppx preview pr to ease testing
- loculus-project/loculus#2975
- loculus-project/loculus#2971
- loculus-project/loculus#2958
- loculus-project/loculus#2969
- loculus-project/loculus#2968

### Comparison
https://github.com/loculus-project/loculus/compare/188eb04e7cca97619b9d5bd048782d20ac196f55...4f8ebb694979e7e4617b0b366c8d8c4ba6c37660

### Preview
https://preview-update-loculus-4f8ebb.pathoplexus.org

> **Note:** This PR targets a non-main branch: `ppx-preview`