### PR TITLE
Update Loculus version to 4f8ecf (non-main: HEAD)

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 188eb04e7cca97619b9d5bd048782d20ac196f55
+loculusVersion: 4f8ecfe7df118c99af191e6942e29965ccd4e651
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@corneliusroemer wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/188eb04e7cca97619b9d5bd048782d20ac196f55 to https://github.com/loculus-project/loculus/commit/4f8ecfe7df118c99af191e6942e29965ccd4e651.


### Changelog
- fix
- Remove unnecessary activation
- fix: log and raise if prepro encounters config error to allow early detection
- loculus-project/loculus#2975
- loculus-project/loculus#2971
- loculus-project/loculus#2958
- loculus-project/loculus#2969
- loculus-project/loculus#2968

### Comparison
https://github.com/loculus-project/loculus/compare/188eb04e7cca97619b9d5bd048782d20ac196f55...4f8ecfe7df118c99af191e6942e29965ccd4e651

### Preview
https://preview-update-loculus-4f8ecf.pathoplexus.org

> **Note:** This PR targets a non-main branch: `HEAD`