### PR TITLE
Update Loculus version to 955043 (non-main: ppx-preview)

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: c723c562ed2ca4a0252b3899fd375dab9a652c5a
+loculusVersion: 955043287cff96289a5045770fd1eee253daecd1
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@corneliusroemer wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/c723c562ed2ca4a0252b3899fd375dab9a652c5a to https://github.com/loculus-project/loculus/commit/955043287cff96289a5045770fd1eee253daecd1.


### Changelog
- Only run on labelling to reduce number of PRs made
- Try to use ref instead of sha for better markup
- Try to use correct payload
- try this instead to use head sha
- woops
- Test empty commit
- feat(ci): allow creation of ppx preview pr to ease testing

### Comparison
https://github.com/loculus-project/loculus/compare/c723c562ed2ca4a0252b3899fd375dab9a652c5a...955043287cff96289a5045770fd1eee253daecd1

### Preview
https://preview-update-loculus-955043.pathoplexus.org

> **Note:** This PR targets a non-main branch: `ppx-preview`