### PR TITLE
Update Loculus version to 3ad6e4

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: c723c562ed2ca4a0252b3899fd375dab9a652c5a
+loculusVersion: 3ad6e423d947eb547bd03e5e2cd633d09a05a9cf
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@corneliusroemer wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/c723c562ed2ca4a0252b3899fd375dab9a652c5a to https://github.com/loculus-project/loculus/commit/3ad6e423d947eb547bd03e5e2cd633d09a05a9cf.


### Changelog
- loculus-project/loculus#2854
- loculus-project/loculus#3012
- loculus-project/loculus#3006
- loculus-project/loculus#3008
- loculus-project/loculus#2993
- loculus-project/loculus#3002
- loculus-project/loculus#2998
- loculus-project/loculus#2995
- loculus-project/loculus#2992
- loculus-project/loculus#2994
- loculus-project/loculus#2996
- loculus-project/loculus#2917
- loculus-project/loculus#2988
- loculus-project/loculus#2981
- loculus-project/loculus#2978
- loculus-project/loculus#2957

### Comparison
https://github.com/loculus-project/loculus/compare/c723c562ed2ca4a0252b3899fd375dab9a652c5a...3ad6e423d947eb547bd03e5e2cd633d09a05a9cf

### Preview
https://preview-update-loculus-3ad6e4.pathoplexus.org