### PR TITLE
Update Loculus version to 712fde

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: c723c562ed2ca4a0252b3899fd375dab9a652c5a
+loculusVersion: 712fde0a6c1f9b8386965c470a98add9672b2ea2
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@corneliusroemer wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/c723c562ed2ca4a0252b3899fd375dab9a652c5a to https://github.com/loculus-project/loculus/commit/712fde0a6c1f9b8386965c470a98add9672b2ea2.


### Changelog
- loculus-project/loculus#3003
- loculus-project/loculus#2854
- loculus-project/loculus#3012
- loculus-project/loculus#3006
- loculus-project/loculus#3008
- loculus-project/loculus#2993
- loculus-project/loculus#3002
- loculus-project/loculus#2998
- loculus-project/loculus#2995
- loculus-project/loculus#2992
- loculus-project/loculus#2994
- loculus-project/loculus#2996
- loculus-project/loculus#2917
- loculus-project/loculus#2988
- loculus-project/loculus#2981
- loculus-project/loculus#2978
- loculus-project/loculus#2957

### Comparison
https://github.com/loculus-project/loculus/compare/c723c562ed2ca4a0252b3899fd375dab9a652c5a...712fde0a6c1f9b8386965c470a98add9672b2ea2

### Preview
https://preview-update-loculus-712fde.pathoplexus.org