### PR TITLE
Update Loculus version to 335f12

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 3850137f74584dc81adc0e969e6491f34912a0dc
+loculusVersion: 335f12fda6ba25156b7314ecad3685309e83a92f
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@anna-parker wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/3850137f74584dc81adc0e969e6491f34912a0dc to https://github.com/loculus-project/loculus/commit/335f12fda6ba25156b7314ecad3685309e83a92f.


### Changelog
- loculus-project/loculus#3077
- loculus-project/loculus#2973
- loculus-project/loculus#3064
- loculus-project/loculus#3052
- loculus-project/loculus#3047
- loculus-project/loculus#3051
- loculus-project/loculus#3040
- loculus-project/loculus#3061
- loculus-project/loculus#3056

### Comparison
https://github.com/loculus-project/loculus/compare/3850137f74584dc81adc0e969e6491f34912a0dc...335f12fda6ba25156b7314ecad3685309e83a92f

### Preview
https://preview-update-loculus-335f12.pathoplexus.org