### PR TITLE
Update Loculus version to 78fec9

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 335f12fda6ba25156b7314ecad3685309e83a92f
+loculusVersion: 78fec968a474b504a0414d56bf8d8551c98cd1d3
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@anna-parker wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/335f12fda6ba25156b7314ecad3685309e83a92f to https://github.com/loculus-project/loculus/commit/78fec968a474b504a0414d56bf8d8551c98cd1d3.


### Changelog
- loculus-project/loculus#3108
- loculus-project/loculus#3098
- loculus-project/loculus#3097
- loculus-project/loculus#3096
- loculus-project/loculus#3103
- loculus-project/loculus#3101
- fix(website): Increase website memory limit to 1024 mb to avoid crashes with very large numbers of deletions
- loculus-project/loculus#3005

### Comparison
https://github.com/loculus-project/loculus/compare/335f12fda6ba25156b7314ecad3685309e83a92f...78fec968a474b504a0414d56bf8d8551c98cd1d3

### Preview
https://preview-update-loculus-78fec9.pathoplexus.org