### PR TITLE
Update Loculus version to 0e4a6f

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 3c20df9f31c6db55a077275b19c0694f09ea2ec1
+loculusVersion: 0e4a6f2c3bf9d482ebadea7a5cc18c43dc3c4bab
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@corneliusroemer wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/3c20df9f31c6db55a077275b19c0694f09ea2ec1 to https://github.com/loculus-project/loculus/commit/0e4a6f2c3bf9d482ebadea7a5cc18c43dc3c4bab.


### Changelog
- loculus-project/loculus#3120
- loculus-project/loculus#3126
- loculus-project/loculus#3111
- loculus-project/loculus#2907
- loculus-project/loculus#3071
- loculus-project/loculus#3063
- loculus-project/loculus#3021
- loculus-project/loculus#3094

### Comparison
https://github.com/loculus-project/loculus/compare/3c20df9f31c6db55a077275b19c0694f09ea2ec1...0e4a6f2c3bf9d482ebadea7a5cc18c43dc3c4bab

### Preview
https://preview-update-loculus-0e4a6f.pathoplexus.org