### PR TITLE
Update Loculus version to 6d2b2d

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 0e4a6f2c3bf9d482ebadea7a5cc18c43dc3c4bab
+loculusVersion: 6d2b2db3a99e8447efb3c8da77bedf3520aeee18
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@corneliusroemer wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/0e4a6f2c3bf9d482ebadea7a5cc18c43dc3c4bab to https://github.com/loculus-project/loculus/commit/6d2b2db3a99e8447efb3c8da77bedf3520aeee18.


### Changelog
- loculus-project/loculus#3129
- loculus-project/loculus#3124
- loculus-project/loculus#3128

### Comparison
https://github.com/loculus-project/loculus/compare/0e4a6f2c3bf9d482ebadea7a5cc18c43dc3c4bab...6d2b2db3a99e8447efb3c8da77bedf3520aeee18

### Preview
https://preview-update-loculus-6d2b2d.pathoplexus.org