### PR TITLE
Update Loculus version to b4f028

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 0e4a6f2c3bf9d482ebadea7a5cc18c43dc3c4bab
+loculusVersion: b4f028e8ffc882d1684cd5b01299d91046d11dcf
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@corneliusroemer wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/0e4a6f2c3bf9d482ebadea7a5cc18c43dc3c4bab to https://github.com/loculus-project/loculus/commit/b4f028e8ffc882d1684cd5b01299d91046d11dcf.


### Changelog
- loculus-project/loculus#3132
- loculus-project/loculus#3141
- loculus-project/loculus#3129
- loculus-project/loculus#3124
- loculus-project/loculus#3128

### Comparison
https://github.com/loculus-project/loculus/compare/0e4a6f2c3bf9d482ebadea7a5cc18c43dc3c4bab...b4f028e8ffc882d1684cd5b01299d91046d11dcf

### Preview
https://preview-update-loculus-b4f028.pathoplexus.org