### PR TITLE
Update Loculus version to 284915

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: b4f028e8ffc882d1684cd5b01299d91046d11dcf
+loculusVersion: 2849151a62e32c4a16819eb2daae8f72fa22beab
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@anna-parker wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/b4f028e8ffc882d1684cd5b01299d91046d11dcf to https://github.com/loculus-project/loculus/commit/2849151a62e32c4a16819eb2daae8f72fa22beab.


### Changelog
- loculus-project/loculus#3147
- loculus-project/loculus#3138

### Comparison
https://github.com/loculus-project/loculus/compare/b4f028e8ffc882d1684cd5b01299d91046d11dcf...2849151a62e32c4a16819eb2daae8f72fa22beab

### Preview
https://preview-update-loculus-284915.pathoplexus.org