### PR TITLE
fix: bring insdc country list up to date

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -125,7 +125,12 @@ defaultOrganismConfig: &defaultOrganismConfig
           inputs:
             input: geoLocCountry
           args:
-            options: # Values from https://www.ebi.ac.uk/ena/browser/api/xml/ERC000011 without NA options
+            options:
+              # Taken from https://www.ncbi.nlm.nih.gov/genbank/collab/country/
+              # Alternative, historically not always up-to-date at https://www.insdc.org/submitting-standards/geo_loc_name-qualifier-vocabulary/
+              # If changed, ensure it's mirrored to Loculus 
+              # Last check: 2024-11-01
+              # Last update: 2024-11-01
               - Afghanistan
               - Albania
               - Algeria
@@ -146,8 +151,8 @@ defaultOrganismConfig: &defaultOrganismConfig
               - Azerbaijan
               - Bahamas
               - Bahrain
-              - Baker Island
               - Baltic Sea
+              - Baker Island
               - Bangladesh
               - Barbados
               - Bassas da India
@@ -196,13 +201,13 @@ defaultOrganismConfig: &defaultOrganismConfig
               - Djibouti
               - Dominica
               - Dominican Republic
-              - East Timor
               - Ecuador
               - Egypt
               - El Salvador
               - Equatorial Guinea
               - Eritrea
               - Estonia
+              - Eswatini
               - Ethiopia
               - Europa Island
               - Falkland Islands (Islas Malvinas)
@@ -270,10 +275,10 @@ defaultOrganismConfig: &defaultOrganismConfig
               - Liberia
               - Libya
               - Liechtenstein
+              - Line Islands
               - Lithuania
               - Luxembourg
               - Macau
-              - Macedonia
               - Madagascar
               - Malawi
               - Malaysia
@@ -287,7 +292,7 @@ defaultOrganismConfig: &defaultOrganismConfig
               - Mayotte
               - Mediterranean Sea
               - Mexico
-              - Micronesia
+              - Micronesia, Federated States of
               - Midway Islands
               - Moldova
               - Monaco
@@ -310,6 +315,7 @@ defaultOrganismConfig: &defaultOrganismConfig
               - Niue
               - Norfolk Island
               - North Korea
+              - North Macedonia
               - North Sea
               - Northern Mariana Islands
               - Norway
@@ -335,9 +341,11 @@ defaultOrganismConfig: &defaultOrganismConfig
               - Ross Sea
               - Russia
               - Rwanda
+              - Saint Barthelemy
               - Saint Helena
               - Saint Kitts and Nevis
               - Saint Lucia
+              - Saint Martin
               - Saint Pierre and Miquelon
               - Saint Vincent and the Grenadines
               - Samoa
@@ -357,14 +365,15 @@ defaultOrganismConfig: &defaultOrganismConfig
               - South Africa
               - South Georgia and the South Sandwich Islands
               - South Korea
+              - South Sudan
               - Southern Ocean
               - Spain
               - Spratly Islands
               - Sri Lanka
+              - State of Palestine
               - Sudan
               - Suriname
               - Svalbard
-              - Swaziland
               - Sweden
               - Switzerland
               - Syria
@@ -373,6 +382,7 @@ defaultOrganismConfig: &defaultOrganismConfig
               - Tanzania
               - Tasman Sea
               - Thailand
+              - Timor-Leste
               - Togo
               - Tokelau
               - Tonga
@@ -383,12 +393,12 @@ defaultOrganismConfig: &defaultOrganismConfig
               - Turkmenistan
               - Turks and Caicos Islands
               - Tuvalu
-              - USA
               - Uganda
               - Ukraine
               - United Arab Emirates
               - United Kingdom
               - Uruguay
+              - USA
               - Uzbekistan
               - Vanuatu
               - Venezuela
@@ -401,6 +411,24 @@ defaultOrganismConfig: &defaultOrganismConfig
               - Yemen
               - Zambia
               - Zimbabwe
+              # Historical Countries in NIH
+              - Belgian Congo
+              - British Guiana
+              - Burma
+              - Czechoslovakia
+              - Czech Republic
+              - East Timor
+              - Korea
+              - Macedonia
+              - Micronesia
+              - Netherlands Antilles
+              - Serbia and Montenegro
+              - Siam
+              - Swaziland
+              - The former Yugoslav Republic of Macedonia
+              - USSR
+              - Yugoslavia
+              - Zaire
       - name: geoLocAdmin1
         displayName: Collection subdivision level 1
         generateIndex: true


### PR DESCRIPTION
When we last changed (fixed) this on Loculus side we forgot to mirror it here. Now there are comments reminding us to check mirroring - also documenting when last changed and where to get them from.