### PR TITLE
Update prepro version

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1083,7 +1083,7 @@ defaultOrganismConfig: &defaultOrganismConfig
   preprocessing:
     - &preprocessing
       replicas: 1
-      version: 2
+      version: 3
       image: ghcr.io/loculus-project/preprocessing-nextclade
       args:
         - "prepro"


### PR DESCRIPTION
Updating the versionComment field is equivalent to adding a new metadata field. 

This now means old sequences in the db do not have this field, but now SILO assumes they do have this field. We need to update the prepro version to give all fields this versionComment. 