### PR TITLE
Update Loculus version to 69d0af

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 2849151a62e32c4a16819eb2daae8f72fa22beab
+loculusVersion: 69d0af6d6a3955d984e9422eed10d28e572c6bb9
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@theosanderson wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/2849151a62e32c4a16819eb2daae8f72fa22beab to https://github.com/loculus-project/loculus/commit/69d0af6d6a3955d984e9422eed10d28e572c6bb9.


### Changelog
- loculus-project/loculus#3149

### Comparison
https://github.com/loculus-project/loculus/compare/2849151a62e32c4a16819eb2daae8f72fa22beab...69d0af6d6a3955d984e9422eed10d28e572c6bb9

### Preview
https://preview-update-loculus-69d0af.pathoplexus.org