### PR TITLE
Fix URL to data submission help page

### DIFF
--- a/monorepo/website/src/components/Submission/dataUploadDocsUrl.ts
+++ b/monorepo/website/src/components/Submission/dataUploadDocsUrl.ts
@@ -1,0 +1,2 @@
+// This variable is in a separate file as it is overwritten by Pathoplexus.
+export const dataUploadDocsUrl = '/docs/how-to/upload-sequences';


### PR DESCRIPTION
This adapts to https://github.com/loculus-project/loculus/pull/3166 and actually fixes the link: previously, the link was to `upload_sequences` but the correct link is `upload-sequences` (a bug I found long time ago but forgot to fix ([slack](https://loculus.slack.com/archives/C05G172HL6L/p1726076972419909))).