### PR TITLE
Update Loculus version to 47a27d

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 2849151a62e32c4a16819eb2daae8f72fa22beab
+loculusVersion: 47a27ddda6d416b37b413e5f34975a3777e9782d
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@anna-parker wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/2849151a62e32c4a16819eb2daae8f72fa22beab to https://github.com/loculus-project/loculus/commit/47a27ddda6d416b37b413e5f34975a3777e9782d.


### Changelog
- loculus-project/loculus#3075
- loculus-project/loculus#3183
- loculus-project/loculus#3181
- loculus-project/loculus#3156
- loculus-project/loculus#3178
- loculus-project/loculus#3062
- loculus-project/loculus#3083
- loculus-project/loculus#3173
- loculus-project/loculus#3175
- loculus-project/loculus#3168
- loculus-project/loculus#3166
- loculus-project/loculus#3165
- loculus-project/loculus#3163
- loculus-project/loculus#3159
- loculus-project/loculus#3157
- loculus-project/loculus#3149

### Comparison
https://github.com/loculus-project/loculus/compare/2849151a62e32c4a16819eb2daae8f72fa22beab...47a27ddda6d416b37b413e5f34975a3777e9782d

### Preview
https://preview-update-loculus-47a27d.pathoplexus.org