### PR TITLE
Update Loculus version to 437d48

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 281b6e8636bdbfcdfec66f0fc08e71fc938fe27e
+loculusVersion: 437d484a102ca8d2ae09f2e60fb6c0785b5ed154
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@anna-parker wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/281b6e8636bdbfcdfec66f0fc08e71fc938fe27e to https://github.com/loculus-project/loculus/commit/437d484a102ca8d2ae09f2e60fb6c0785b5ed154.


### Changelog
- loculus-project/loculus#3229
- loculus-project/loculus#3227

### Comparison
https://github.com/loculus-project/loculus/compare/281b6e8636bdbfcdfec66f0fc08e71fc938fe27e...437d484a102ca8d2ae09f2e60fb6c0785b5ed154

### Preview
https://preview-update-loculus-437d48.pathoplexus.org