### PR TITLE
Update Loculus version to f8c404

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 0fdac51a1db9357bf24267e824307b0b026b715d
+loculusVersion: f8c404808c96846c932ed5ad2491d59b87adb23b
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@corneliusroemer wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/0fdac51a1db9357bf24267e824307b0b026b715d to https://github.com/loculus-project/loculus/commit/f8c404808c96846c932ed5ad2491d59b87adb23b.
### 🚨 Breaking Changes
- loculus-project/loculus#3304

### Changelog
- loculus-project/loculus#3304
- loculus-project/loculus#3337
- loculus-project/loculus#3350
- loculus-project/loculus#3308
- loculus-project/loculus#3342
- loculus-project/loculus#3335
- loculus-project/loculus#3339
- loculus-project/loculus#3329

### Comparison
https://github.com/loculus-project/loculus/compare/0fdac51a1db9357bf24267e824307b0b026b715d...f8c404808c96846c932ed5ad2491d59b87adb23b

### Preview
https://preview-update-loculus-f8c404.pathoplexus.org