### PR TITLE
Update Loculus version to ee77b4

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 62beeb7ed8308679896112958899f77c23655494
+loculusVersion: ee77b4a9761ca4e8b64b65aad95405f501d92105
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@corneliusroemer wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/62beeb7ed8308679896112958899f77c23655494 to https://github.com/loculus-project/loculus/commit/ee77b4a9761ca4e8b64b65aad95405f501d92105.


### Changelog
- loculus-project/loculus#3381
- loculus-project/loculus#3073
- loculus-project/loculus#3377
- loculus-project/loculus#3366
- loculus-project/loculus#3367

### Comparison
https://github.com/loculus-project/loculus/compare/62beeb7ed8308679896112958899f77c23655494...ee77b4a9761ca4e8b64b65aad95405f501d92105

### Preview
https://preview-update-loculus-ee77b4.pathoplexus.org