### PR TITLE
Update Loculus version to 1e70d5

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: ee77b4a9761ca4e8b64b65aad95405f501d92105
+loculusVersion: 1e70d5041eed4084f46966a2fbe36c9ba56ce30a
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@corneliusroemer wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/ee77b4a9761ca4e8b64b65aad95405f501d92105 to https://github.com/loculus-project/loculus/commit/1e70d5041eed4084f46966a2fbe36c9ba56ce30a.


### Changelog
- loculus-project/loculus#3396
- loculus-project/loculus#3383
- loculus-project/loculus#3385

### Comparison
https://github.com/loculus-project/loculus/compare/ee77b4a9761ca4e8b64b65aad95405f501d92105...1e70d5041eed4084f46966a2fbe36c9ba56ce30a

### Preview
https://preview-update-loculus-1e70d5.pathoplexus.org