### PR TITLE
Update Loculus version to bedf86

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: ee77b4a9761ca4e8b64b65aad95405f501d92105
+loculusVersion: bedf866d5e74df2fb3ca2a68a1c4a6d559db6cd0
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@corneliusroemer wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/ee77b4a9761ca4e8b64b65aad95405f501d92105 to https://github.com/loculus-project/loculus/commit/bedf866d5e74df2fb3ca2a68a1c4a6d559db6cd0.


### Changelog
- loculus-project/loculus#3402
- loculus-project/loculus#3396
- loculus-project/loculus#3383
- loculus-project/loculus#3385

### Comparison
https://github.com/loculus-project/loculus/compare/ee77b4a9761ca4e8b64b65aad95405f501d92105...bedf866d5e74df2fb3ca2a68a1c4a6d559db6cd0

### Preview
https://preview-update-loculus-bedf86.pathoplexus.org