### PR TITLE
Update Loculus version to 1ae4ed

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: ee77b4a9761ca4e8b64b65aad95405f501d92105
+loculusVersion: 1ae4ed09a61b02f4283fe192e55e3e3054723f33
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@corneliusroemer wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/ee77b4a9761ca4e8b64b65aad95405f501d92105 to https://github.com/loculus-project/loculus/commit/1ae4ed09a61b02f4283fe192e55e3e3054723f33.


### Changelog
- loculus-project/loculus#3403
- loculus-project/loculus#3402
- loculus-project/loculus#3396
- loculus-project/loculus#3383
- loculus-project/loculus#3385

### Comparison
https://github.com/loculus-project/loculus/compare/ee77b4a9761ca4e8b64b65aad95405f501d92105...1ae4ed09a61b02f4283fe192e55e3e3054723f33

### Preview
https://preview-update-loculus-1ae4ed.pathoplexus.org