### PR TITLE
Update Loculus version to b61c43

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: bd9fcbce9e05e952cf91cbcf9a56125ddd063346
+loculusVersion: b61c437d079d16847cc04f3be6188f4bb26eced4
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@corneliusroemer wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/bd9fcbce9e05e952cf91cbcf9a56125ddd063346 to https://github.com/loculus-project/loculus/commit/b61c437d079d16847cc04f3be6188f4bb26eced4.


### Changelog
- loculus-project/loculus#3417
- loculus-project/loculus#3411
- loculus-project/loculus#3415
- loculus-project/loculus#3416
- loculus-project/loculus#3418
- loculus-project/loculus#3410

### Comparison
https://github.com/loculus-project/loculus/compare/bd9fcbce9e05e952cf91cbcf9a56125ddd063346...b61c437d079d16847cc04f3be6188f4bb26eced4

### Preview
https://preview-update-loculus-b61c43.pathoplexus.org