### PR TITLE
Update Loculus version to 162a4e

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: b61c437d079d16847cc04f3be6188f4bb26eced4
+loculusVersion: 162a4ee80918849b2f05aa5328a5f3105b60c984
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
@theosanderson wants to update the Loculus version from https://github.com/loculus-project/loculus/commit/b61c437d079d16847cc04f3be6188f4bb26eced4 to https://github.com/loculus-project/loculus/commit/162a4ee80918849b2f05aa5328a5f3105b60c984.


### Changelog
- loculus-project/loculus#3419

### Comparison
https://github.com/loculus-project/loculus/compare/b61c437d079d16847cc04f3be6188f4bb26eced4...162a4ee80918849b2f05aa5328a5f3105b60c984

### Preview
https://preview-update-loculus-162a4e.pathoplexus.org