### PR TITLE
Add SIB Affiliation for Members; Add Treasurer to Chaoran

### DIFF
--- a/monorepo/website/src/pages/about/development-team.mdx
+++ b/monorepo/website/src/pages/about/development-team.mdx
@@ -30,14 +30,14 @@ import mikeMartin from "../../images/mikeMartin-square.jpg"
 import arthurShem from "../../images/kasambulaArthurShem-square.jpg"
 
 export const members = [
-    { name: "Emma Hodcroft", description: "Swiss TPH; University of Basel", picture: emmaHodcroft },
+    { name: "Emma Hodcroft", description: "Swiss TPH; University of Basel; SIB", picture: emmaHodcroft },
     { name: "Theo Sanderson", description: "London School of Hygiene & Tropical Medicine", picture: theoSanderson },
-    { name: "Chaoran Chen", description: "ETH Zurich", picture: chaoranChen },
-    { name: "Cornelius Roemer", description: "University of Basel", picture: corneliusRoemer },
-    { name: "Alex Taepper", description: "ETH Zurich", picture: alexTaepper },
-    { name: "Anna Parker", description: "ETH Zurich", picture: annaParker },
-    { name: "Tanja Stadler", description: "ETH Zurich", picture: tanjaStadler },
-    { name: "Richard Neher", description: "University of Basel", picture: richardNeher },
+    { name: "Chaoran Chen", description: "ETH Zurich; SIB", picture: chaoranChen },
+    { name: "Cornelius Roemer", description: "University of Basel; SIB", picture: corneliusRoemer },
+    { name: "Alex Taepper", description: "ETH Zurich; SIB", picture: alexTaepper },
+    { name: "Anna Parker", description: "ETH Zurich; SIB", picture: annaParker },
+    { name: "Tanja Stadler", description: "ETH Zurich; SIB", picture: tanjaStadler },
+    { name: "Richard Neher", description: "University of Basel; SIB", picture: richardNeher },
     { name: "Fabian Engelniederhammer", description: "TNG", picture: fabianEngelniederhammer },
     { name: "Tobias Kampmann", description: "TNG", picture: tobiasKampmann },
     { name: "Jonas Zarzalis", description: "TNG", picture: jonasKellerer },
@@ -50,13 +50,13 @@ export const members = [
 export const curators = [
     { name: "Emily Smith", description: "Theiagen Genomics", picture: emilySmith},
     { name: "Gültekin Ünal", description: "Ankara University", picture: gultekinUnal}, 
-    { name: "Emma Hodcroft", description: "Swiss TPH; University of Basel", picture: emmaHodcroft },
+    { name: "Emma Hodcroft", description: "Swiss TPH; University of Basel; SIB", picture: emmaHodcroft },
     { name: "Theo Sanderson", description: "Francis Crick Institute", picture: theoSanderson },
-    { name: "Chaoran Chen", description: "ETH Zurich", picture: chaoranChen },
-    { name: "Cornelius Roemer", description: "University of Basel", picture: corneliusRoemer },
+    { name: "Chaoran Chen", description: "ETH Zurich; SIB", picture: chaoranChen },
+    { name: "Cornelius Roemer", description: "University of Basel; SIB", picture: corneliusRoemer },
     { name: "Mike Martin", description: "Johns Hopkins School of Public Health", picture: mikeMartin },
     { name: "Arthur Shem Kasambula", description: "Makerere University", picture: arthurShem },
-    { name: "Anna Parker", description: "ETH Zurich", picture: annaParker },
+    { name: "Anna Parker", description: "ETH Zurich; SIB", picture: annaParker },
 ];
 
 ## The Development Team

--- a/monorepo/website/src/pages/about/eb.mdx
+++ b/monorepo/website/src/pages/about/eb.mdx
@@ -17,13 +17,13 @@ export const members = [
     {
         name: "Emma Hodcroft",
         description: "Evolution, phylogenetics", 
-        affiliation: "Swiss TPH, University of Basel, SIB, Switzerland",
+        affiliation: "Swiss TPH; University of Basel; SIB: Switzerland",
         picture: emmaHodcroft
     },
     {
         name: "George Githinji",
         description: "Evolution, phylogenetics", 
-        affiliation: "KEMRI-Wellcome Trust Research Programme, Kenya",
+        affiliation: "KEMRI-Wellcome Trust Research Programme: Kenya",
         picture: georgeGithinji
     },
     {
@@ -35,13 +35,13 @@ export const members = [
     {
         name: "Anderson Brito",
         description: "Virology, public health", 
-        affiliation: "Instituto Todos pela Saúde, Brazil",
+        affiliation: "Instituto Todos pela Saúde: Brazil",
         picture: andersonBrito
     },
     {
         name: "Tommy Lam",
         description: "Software development, evolution", 
-        affiliation: "The University of Hong Kong, Hong Kong",
+        affiliation: "The University of Hong Kong: Hong Kong",
         picture: tommyLam
     }
 ];

--- a/monorepo/website/src/pages/about/eb.mdx
+++ b/monorepo/website/src/pages/about/eb.mdx
@@ -17,7 +17,7 @@ export const members = [
     {
         name: "Emma Hodcroft",
         description: "Evolution, phylogenetics", 
-        affiliation: "Swiss TPH, Switzerland",
+        affiliation: "Swiss TPH, University of Basel, SIB, Switzerland",
         picture: emmaHodcroft
     },
     {

--- a/monorepo/website/src/pages/about/members.mdx
+++ b/monorepo/website/src/pages/about/members.mdx
@@ -40,7 +40,7 @@ export const members = [
     { name: "Anja Bedeker", description: "", picture: anjaBedeker},
     { name: "Anna Parker", description: "", picture: annaParker },
     { name: "Artem Babaian", description: "", picture: artemBabaian },
-    { name: "Chaoran Chen", description: "", picture: chaoranChen },
+    { name: "Chaoran Chen", description: "Treasurer", picture: chaoranChen },
     { name: "Cornelius Roemer", description: "", picture: corneliusRoemer },
     { name: "Emily Smith", description: "", picture: emilySmith},
     { name: "Emma Griffiths", description: "", picture: emmaGriffiths},


### PR DESCRIPTION
- Adds SIB affiliation to all associated people at ETH Zurich, UniBas, & Swiss TPH (developers page)
- Adds SIB affiliation to Emma on EB page (and change show affiliations show up slightly to make multiple affiliations clearer)
- Adds 'Treasurer' to Chaoran on members page
