### PR TITLE
Remove unused metadata fields

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -771,13 +771,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Canada, Vancouver; USA, Seattle; Italy, Milan
         displayName: Travel history
         header: Host
-      - name: exposureEvent
-        ontology_id: GENEPIO:0001417
-        definition: Event leading to exposure.
-        guidance: If known, select the exposure event from the pick list.
-        example: Mass Gathering [GENEPIO:0100237]
-        displayName: Exposure event
-        header: Host
       - name: hostRole
         ontology_id: GENEPIO:0001419
         definition: The role of the host in relation to the exposure setting.
@@ -787,7 +780,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         header: Host
       - name: exposureSetting
         ontology_id: GENEPIO:0001428
-        definition: The setting leading to exposure.
+        definition: The setting or event leading to exposure.
         guidance: Select the host exposure setting(s) from the pick list provided in the template. If a desired term is missing, contact the curation team.
         example: Healthcare Setting [GENEPIO:0100201]
         displayName: Exposure setting
@@ -804,12 +797,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         guidance: Provide the name(s) of the previous of ongoing disease(s). Multiple diseases can be separated by a semi-colon.
         example: COVID-19
         displayName: Previous infection (disease)
-        header: Host
-      - name: previousInfectionOrganism
-        definition: The name of the pathogen causing the disease previously experienced by the host.
-        guidance: Provide the name(s) of the pathogen(s) causing the previous or ongoing infections. Multiple pathogen names can be separated using a semi-colon.
-        example: Sudden Acute Respiratory Syndrome Coronavirus 2 (SARS-CoV-2)
-        displayName: Previous infection (organism)
         header: Host
       - name: hostVaccinationStatus
         ontology_id: GENEPIO:0001404
@@ -907,13 +894,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Nanostripper 1.2.3
         displayName: Dehosting method
         header: Sequencing
-      - name: referenceGenomeAccession
-        ontology_id: GENEPIO:0001485
-        definition: A persistent, unique identifier of a genome database entry.
-        guidance: Provide the accession number of the reference genome used for mapping/assembly.
-        example: NC_045512.2
-        displayName: Reference genome accession
-        header: Sequencing
       - name: consensusSequenceSoftwareName
         ontology_id: GENEPIO:0001463
         definition: The name of software used to generate the consensus sequence.
@@ -944,41 +924,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Breadth of coverage
         type: int
         header: Sequencing
-      - name: qualityControlMethodName
-        ontology_id: GENEPIO:0100557
-        definition: The name of the method used to assess whether a sequence passed a predetermined quality control threshold.
-        guidance: Providing the name of the method used for quality control is very important for interpreting the rest of the QC information. Method names can be provided as the name of a pipeline or a link to a GitHub repository. Multiple methods should be listed and separated by a semi-colon. Do not include QC tags in other fields if no method name is provided.
-        example: ncov-tools
-        displayName: Quality control method name
-        header: Sequencing
-      - name: qualityControlMethodVersion
-        ontology_id: GENEPIO:0100558
-        definition: The version number of the method used to assess whether a sequence passed a predetermined quality control threshold.
-        guidance: Methods updates can make big differences to their outputs. Provide the version of the method used for quality control. The version can be expressed using whatever convention the developer implements (e.g. date, semantic versioning). If multiple methods were used, record the version numbers in the same order as the method names. Separate the version numbers using a semi-colon.
-        example: "1.2.3"
-        displayName: Quality control method version
-        header: Sequencing
-      - name: qualityControlDetermination
-        ontology_id: GENEPIO:0100559
-        definition: The determination of a quality control assessment.
-        guidance: Select a value from the pick list provided. If a desired value is missing, submit a new term request to the PHA4GE QC Tag GitHub issuetracker using the New Term Request form.
-        example: sequence failed quality control
-        displayName: Quality control determination
-        header: Sequencing
-      - name: qualityControlIssues
-        ontology_id: GENEPIO:0100560
-        definition: The reason contributing to, or causing, a low quality determination in a quality control assessment.
-        guidance: Select a value from the pick list provided. If a desired value is missing, submit a new term request to the PHA4GE QC Tag GitHub issuetracker using the New Term Request form.
-        example: low average genome coverage
-        displayName: Quality control issues
-        header: Sequencing
-      - name: qualityControlDetails
-        ontology_id: GENEPIO:0100561
-        definition: The details surrounding a low quality determination in a quality control assessment.
-        guidance: Provide notes or details regarding QC results using free text.
-        example: CT value of 39. Low viral load. Low DNA concentration after amplification.
-        displayName: Quality control details
-        header: Diagnostics
       - name: diagnosticMeasurementMethod
         displayName: Diagnostic measurement method
         header: Diagnostics
@@ -990,9 +935,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         header: Diagnostics
       - name: diagnosticMeasurementValue
         displayName: Diagnostic measurement value
-        header: Diagnostics
-      - name: diagnosticMeasurementUnit
-        displayName: Diagnostic measurement unit
+        definition: The value of the diagnostic measurement with units.
         header: Diagnostics
       - name: length
         type: int


### PR DESCRIPTION
When going over the metadata fields I found a number of fields that we do not use and we should probably not allow users to input as this will confuse other users. 

These are 
- referenceGenomeAccession: We align sequences to a reference and should not allow users to specify this value themselves
-  qualityControlMethodName, qualityControlMethodVersion, qualityControlDetermination, qualityControlIssues, qualityControlDetails: we perform our own QC on sequences and show these results adding additional QC values from submitters will be confusing and is not needed

We can also condense certain fields to reduce metadata schema bloat: 
- diagnosticMeasurementValue and diagnosticMeasurementUnit can be joined
- previousInfectionOrganism 
 is not required as previousInfectionDisease is also an option and should include these details
- exposureSetting and exposureEvent can be joined