### PR TITLE
feat: Enable earliest release date

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -50,6 +50,10 @@ defaultOrganismConfig: &defaultOrganismConfig
     loadSequencesAutomatically: true
     organismName: "Ebola Zaire"
     image: "/images/organisms/ebolazaire_small.jpg"
+    earliestReleaseDate:
+      enabled: true
+      externalFields:
+        - ncbiReleaseDate
     ### Field list
     ## General fields
     # name: Key used across app to refer to this field (required)
@@ -149,6 +153,12 @@ defaultOrganismConfig: &defaultOrganismConfig
         noInput: true
         columnWidth: 90
         order: 90
+      - name: earliestReleaseDate
+        displayName: Earliest release date
+        header: Sample details
+        type: date
+        rangeSearch: true
+        noInput: true
       - name: ncbiUpdateDate
         type: date
         displayName: NCBI update date


### PR DESCRIPTION
The earliest release date feature was added to loculus in this PR: https://github.com/loculus-project/loculus/pull/3380/files#diff-8c45270b76bf36f08f571b509614d6672984b0604844a487a0ad3ba2ad794943

But to use it, changes to the values.yaml need to be made.