### PR TITLE
Apply metadata template to all organisms

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1203,6 +1203,24 @@ defaultOrganismConfig: &defaultOrganismConfig
     silo:
       dateToSortBy: sampleCollectionDateRangeUpper
     extraInputFields: []
+    metadataTemplate:
+      - geoLocCountry  
+      - sampleCollectionDate  
+      - authorAffiliations  
+      - authors  
+      - collectionDevice  
+      - collectionMethod  
+      - cultureId  
+      - depthOfCoverage  
+      - geoLocAdmin1  
+      - geoLocAdmin2  
+      - hostNameScientific  
+      - sampleReceivedDate  
+      - sequencingDate  
+      - sequencingInstrument  
+      - sequencingProtocol  
+      - specimenCollectorSampleId  
+      - versionComment  
   preprocessing:
     - &preprocessing
       replicas: 1
@@ -1263,24 +1281,6 @@ organisms:
       <<: *schema
       organismName: "Ebola Sudan"
       image: "/images/organisms/ebolasudan_small.jpg"
-      metadataTemplate: 
-        - geoLocCountry  
-        - sampleCollectionDate  
-        - authorAffiliations  
-        - authors  
-        - collectionDevice  
-        - collectionMethod  
-        - cultureId  
-        - depthOfCoverage  
-        - geoLocAdmin1  
-        - geoLocAdmin2  
-        - hostNameScientific  
-        - sampleReceivedDate  
-        - sequencingDate  
-        - sequencingInstrument  
-        - sequencingProtocol  
-        - specimenCollectorSampleId  
-        - versionComment    
       metadataAdd:
         - name: totalStopCodons
           type: int

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1206,15 +1206,15 @@ defaultOrganismConfig: &defaultOrganismConfig
     metadataTemplate:
       - geoLocCountry  
       - sampleCollectionDate  
-      - authorAffiliations  
       - authors  
+      - authorAffiliations  
+      - hostNameScientific  
       - collectionDevice  
       - collectionMethod  
       - cultureId  
       - depthOfCoverage  
       - geoLocAdmin1  
       - geoLocAdmin2  
-      - hostNameScientific  
       - sampleReceivedDate  
       - sequencingDate  
       - sequencingInstrument  


### PR DESCRIPTION
In #351 we added a shorter metadata template for Ebola sudan. Here we instead apply this same template across all Pathoplexus organisms.

This also slights reorders the template. 

I've tested that it renders as expected across organisms.

http://preview-template.pathoplexus.org