### PR TITLE
feat(website): use Pathoplexus' own metadata docs page

### DIFF
--- a/monorepo/website/src/components/Submission/metadataFormatDocsUrl.ts
+++ b/monorepo/website/src/components/Submission/metadataFormatDocsUrl.ts
@@ -1,0 +1,2 @@
+// This variable is in a separate file as it is overwritten by Pathoplexus.
+export const metadataFormatDocsUrl = '/docs/concepts/metadataformat';


### PR DESCRIPTION
This is to configure the website to keep using Pathoplexus' own metadata docs page after https://github.com/loculus-project/loculus/pull/3634.