### PR TITLE
fix(values): Make example field values strings

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -539,14 +539,14 @@ defaultOrganismConfig: &defaultOrganismConfig
         type: float
         definition: Geo-coordinate latitude in decimal degree (WGS84) format
         guidance: Provide values in range -90 to 90, where positive values are north of the Equator.
-        example: -34.603722
+        example: "-34.603722"
       - name: geoLocLongitude
         displayName: Longitude
         header: Sample details
         type: float
         definition: Geo-coordinate longitude in decimal degree (WGS84) format
         guidance: Provide values in range -180 to 180, where positive values are east of the Prime Meridian.
-        example: -58.381592
+        example: "-58.381592"
       - name: specimenCollectorSampleId
         displayName: Isolate name
         header: Sample details


### PR DESCRIPTION
`example` values are of type String (https://loculus.org/reference/helm-chart-config/#metadata-type)