### PR TITLE
Boost memory for LAPIS and SILO in prod

### DIFF
--- a/loculus_values/environment_specific_values/production.yaml
+++ b/loculus_values/environment_specific_values/production.yaml
@@ -107,16 +107,16 @@ resources:
       memory: "3Gi"
   silo:
     requests:
-      memory: "500Mi"
+      memory: "1Gi"
       cpu: "1000m"
     limits:
-      memory: "10Gi"
+      memory: "1Gi"
   lapis:
     requests:
-      memory: "220Mi"
+      memory: "1Gi"
       cpu: "1000m"
     limits:
-      memory: "5Gi"
+      memory: "1Gi"
   silo-preprocessing:
     requests:
       memory: "20Mi"


### PR DESCRIPTION
Mpox is crashing in prod with sequence downloads. This PR:

- boosts the request memory (i.e. the amount reserved)
- decreases the limit to be the same as the requested amount so that things are not determined by outside availability which could mask problems