### PR TITLE
Specify specific resource requirements for mpox prod

### DIFF
--- a/loculus_values/environment_specific_values/production.yaml
+++ b/loculus_values/environment_specific_values/production.yaml
@@ -147,6 +147,11 @@ resources:
           memory: "1Gi"
         limits:
           memory: "1Gi"
+      silo-preprocessing:
+        requests:
+          memory: "3Gi"
+        limits:
+          memory: "3Gi"
 defaultResources:
   requests:
     memory: "200Mi"

--- a/loculus_values/environment_specific_values/production.yaml
+++ b/loculus_values/environment_specific_values/production.yaml
@@ -135,6 +135,18 @@ resources:
       cpu: "200m"
     limits:
       memory: "3Gi"
+  organismSpecific:
+    mpox:
+      silo:
+        requests:
+          memory: "10Gi"
+        limits:
+          memory: "10Gi"
+      lapis:
+        requests:
+          memory: "1Gi"
+        limits:
+          memory: "1Gi"
 defaultResources:
   requests:
     memory: "200Mi"


### PR DESCRIPTION
Adds specific resource requirements for mpox on prod to avoid crashing. Only relevant once we bump Loculus to include https://github.com/loculus-project/loculus/pull/3680 .