### PR TITLE
fix(config): remove generateIndex for boolean values as currently not supported by SILO

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1089,7 +1089,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         guidance: "Use https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi to find taxon ids."
         example: "9606"
       - name: isLabHost
-        generateIndex: true
         autocomplete: true
         header: "Host"
         ingest: ncbiIsLabHost


### PR DESCRIPTION
Resolves: https://github.com/pathoplexus/pathoplexus/issues/407

Preview: https://preview-fix-boolean.pathoplexus.org/