### PR TITLE
Include author, author affiliations, and INSDC accession in metadata downloads by default

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -627,6 +627,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         oneHeader: true
       - name: insdcAccessionFull
         displayName: INSDC accession
+        includeInDownloadsByDefault: true
         customDisplay:
           type: link
           url: "https://www.ncbi.nlm.nih.gov/nuccore/__value__"

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -579,6 +579,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         enableSubstringSearch: true
         truncateColumnDisplayTo: 15
         ingest: ncbiSubmitterNames
+        includeInDownloadsByDefault: true
         preprocessing:
           function: check_authors
           inputs:
@@ -594,6 +595,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         generateIndex: true
         autocomplete: true
         truncateColumnDisplayTo: 15
+        includeInDownloadsByDefault: true
         header: Authors
         ingest: ncbiSubmitterAffiliation
         enableSubstringSearch: true


### PR DESCRIPTION
This was accidentally left off