### PR TITLE
Update mpox dataset version to 2025-04-25

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1599,8 +1599,9 @@ organisms:
         defaultOrder: descending
     preprocessing:
       - <<: *preprocessing
-        replicas: 3
-        configFile:
+        replicas: 1
+        version: 8
+        configFile: &mpoxPreprocessingConfigFile
           <<: *preprocessingConfigFile
           nextclade_dataset_name: nextstrain/mpox/all-clades
           nextclade_dataset_version: 2024-11-19--14-18-53Z
@@ -1781,6 +1782,12 @@ organisms:
             - OPG208
             - OPG209
             - OPG210
+      - <<: *preprocessing
+        replicas: 3
+        version: 9
+        configFile:
+          <<: *mpoxPreprocessingConfigFile
+          nextclade_dataset_version: 2025-04-25--12-24-24Z
     ingest:
       <<: *ingest
       configFile:


### PR DESCRIPTION
Standard dataset update: adding new prepro version (9 in this case), keeping old one as is. Once upgrade is completed we can remove version 8 list item.

There are no clade/lineage changes between old and new version so differences should be small.

Using a yaml anchor & to avoid having to repeat the genes and keep the diff small.

Preview: https://preview-update-mpox-dataset.pathoplexus.org/