### PR TITLE
Remove `dateToSortBy` now deprecated in SILO

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1239,7 +1239,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         - length
       defaultOrderBy: sampleCollectionDate
       defaultOrder: descending
-    silo:
     extraInputFields: []
     metadataTemplate:
       - geoLocCountry  

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1240,7 +1240,6 @@ defaultOrganismConfig: &defaultOrganismConfig
       defaultOrderBy: sampleCollectionDate
       defaultOrder: descending
     silo:
-      dateToSortBy: sampleCollectionDateRangeUpper
     extraInputFields: []
     metadataTemplate:
       - geoLocCountry  


### PR DESCRIPTION
Don't merge this until after a corresponding change to Loculus