### PR TITLE
Make stop codons per segment

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1472,11 +1472,13 @@ organisms:
           type: int
           header: "Alignment and QC metrics"
           noInput: true
+          perSegment: true
           preprocessing:
             inputs: {input: nextclade.qc.stopCodons.totalStopCodons}
         - name: stopCodons
           header: "Alignment and QC metrics"
           noInput: true
+          perSegment: true
           preprocessing:
             inputs: {input: nextclade.qc.stopCodons.stopCodons}
       website:


### PR DESCRIPTION
It's weird that for CCHF stop codons are on their own as QC that is not per segment:

<img width="723" alt="image" src="https://github.com/user-attachments/assets/e4841bda-5698-4311-8942-3c51534a1ea7" />

This tries to address that though I'm not sure what will happen