### PR TITLE
Various changes to submission docs

### DIFF
--- a/monorepo/website/src/pages/docs/how-to/upload-sequences.mdx
+++ b/monorepo/website/src/pages/docs/how-to/upload-sequences.mdx
@@ -9,10 +9,10 @@ You can only upload sequences if you have [created an account](create-account) a
 
 Before you begin this process, you should ensure your data is in the correct format. Each sequence should have a unique submissionID that can be used to associate it with its corresponding metadata entry.
 
-Loculus expects:
+The expected data format is as follows:
 
-- Sequence data in `fasta` format with a unique submissionID per sequence.
-- Metadata in `tsv` format for each sequence. You can read more about the required metadata fields [here](../concepts/metadataformat). If you need help formatting metadata we offer a metadata template for each organism on the submission page.
+- Sequence data in `fasta` format with each header containing the unique submissionID of the sequence.
+- Metadata in `tsv` format for each sequence. You can read more about the required metadata fields [here](../concepts/metadataformat). A metadata template is provided for each organism on the submission page.
 
 ![Metadata template.](../../../images/MetadataTemplate.png)
 
@@ -24,7 +24,7 @@ _You can try out uploading sequences to our [Demo Instance](https://demo.pathopl
 
 ### Multi-segmented Pathogens
 
-Pathoplexus expects multi-segmented pathogens to have one unique submissionID per **isolate** (pathogen sample containing all segments). However, `fasta` files should still have a separate entry/record per segment. Therefore, each record id should include the unique submissionID of the isolate and the segment name, for example: `submissionID + '_' + segmentName`. The metadata is uploaded per isolate, i.e. there will be only one row for each `submissionID` and segmented metadata parameters need to be uploaded individually, i.e. under `length_{segmentName}` etc.
+Pathoplexus expects multi-segmented pathogen sequence data to have one unique submissionID per **isolate** (pathogen sample containing all segments). However, `fasta` files should still have a separate entry/record per segment. Therefore, each record id should include the unique submissionID of the isolate and the segment name, for example: `submissionID + '_' + segmentName`. The metadata is uploaded per isolate, i.e. there will be only one row for each `submissionID`.
 
 ## Website
 


### PR DESCRIPTION
Rationale includes:
- reference to "Loculus" is confusing
- the previous version implied you have to upload data on the length of segments but length is automatically calculated