### PR TITLE
Reduce prod CPU requests for silo, lapis, silo-preprocessing for all but mpox

### DIFF
--- a/loculus_values/environment_specific_values/production.yaml
+++ b/loculus_values/environment_specific_values/production.yaml
@@ -109,19 +109,19 @@ resources:
   silo:
     requests:
       memory: "2Gi"
-      cpu: "1000m"
+      cpu: "500m"
     limits:
       memory: "2Gi"
   lapis:
     requests:
       memory: "220Mi"
-      cpu: "1000m"
+      cpu: "500m"
     limits:
       memory: "5Gi"
   silo-preprocessing:
     requests:
       memory: "20Mi"
-      cpu: "1000m"
+      cpu: "500m"
     limits:
       memory: "10Gi"
   backend:

--- a/loculus_values/environment_specific_values/production.yaml
+++ b/loculus_values/environment_specific_values/production.yaml
@@ -109,13 +109,13 @@ resources:
   silo:
     requests:
       memory: "2Gi"
-      cpu: "500m"
+      cpu: "1000m"
     limits:
       memory: "2Gi"
   lapis:
     requests:
       memory: "220Mi"
-      cpu: "500m"
+      cpu: "1000m"
     limits:
       memory: "5Gi"
   silo-preprocessing:


### PR DESCRIPTION
Go from 1 to 0.5 cpus, this only reduces requests and allows us to pack more previews alongside prod.

Prod will thus be guaranteed a little less CPU but we're almost never really CPU limited anyways - it's just we have limited CPU to _promise_
