### PR TITLE
Add GitHub workflow to check helm templating works correctly

### DIFF
--- a/.github/workflows/helm-template-check.yml
+++ b/.github/workflows/helm-template-check.yml
@@ -1,0 +1,87 @@
+name: Helm Template Check
+
+on:
+  pull_request:
+    paths:
+      - 'loculus_values/**'
+      - 'pathoplexus_app/**'
+      - '.github/workflows/helm-template-check.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'loculus_values/**'
+      - 'pathoplexus_app/**'
+      - '.github/workflows/helm-template-check.yml'
+
+jobs:
+  get-environments:
+    runs-on: ubuntu-latest
+    outputs:
+      environments: ${{ steps.get-envs.outputs.environments }}
+    steps:
+      - name: Checkout Pathoplexus repository
+        uses: actions/checkout@v4
+
+      - name: Get environment list
+        id: get-envs
+        run: |
+          # Get all .yaml files in environment_specific_values and extract just the filename without extension
+          environments=$(ls loculus_values/environment_specific_values/*.yaml | xargs -n 1 basename | sed 's/\.yaml$//' | jq -R -s -c 'split("\n")[:-1]')
+          echo "environments=$environments" >> $GITHUB_OUTPUT
+          echo "Found environments: $environments"
+
+  helm-template:
+    needs: get-environments
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        environment: ${{ fromJson(needs.get-environments.outputs.environments) }}
+    steps:
+      - name: Checkout Pathoplexus repository
+        uses: actions/checkout@v4
+        with:
+          path: pathoplexus
+
+      - name: Get Loculus version
+        id: loculus-version
+        run: |
+          LOCULUS_VERSION=$(grep 'loculusVersion:' pathoplexus/pathoplexus_app/values.yaml | awk '{print $2}' | tr -d '"')
+          echo "version=$LOCULUS_VERSION" >> $GITHUB_OUTPUT
+
+      - name: Checkout Loculus repository
+        uses: actions/checkout@v4
+        with:
+          repository: loculus-project/loculus
+          ref: ${{ steps.loculus-version.outputs.version }}
+          path: loculus
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4
+        with:
+          version: 'v3.14.0'
+
+      - name: Template Helm chart for ${{ matrix.environment }}
+        run: |
+          helm template kubernetes/loculus \
+            --name-template loculus-pp-${{ matrix.environment }} \
+            --namespace ${{ matrix.environment }} \
+            --kube-version 1.29 \
+            --values kubernetes/loculus/values.yaml \
+            --values ../pathoplexus/loculus_values/values.yaml \
+            --values ../pathoplexus/loculus_values/environment_specific_values/${{ matrix.environment }}.yaml \
+            > /dev/null
+        working-directory: loculus
+
+      - name: Template Helm chart with debug output
+        if: failure()
+        run: |
+          helm template kubernetes/loculus \
+            --name-template loculus-pp-${{ matrix.environment }} \
+            --namespace ${{ matrix.environment }} \
+            --kube-version 1.29 \
+            --values kubernetes/loculus/values.yaml \
+            --values ../pathoplexus/loculus_values/values.yaml \
+            --values ../pathoplexus/loculus_values/environment_specific_values/${{ matrix.environment }}.yaml \
+            --debug
+        working-directory: loculus


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that validates our Helm templating for all defined environments (staging, production, demo, main). The workflow ensures that our Helm charts can be successfully templated with the appropriate values for each environment.

### Changes
- Added `.github/workflows/helm-template-check.yml` workflow that:
  - Dynamically discovers all environments from `loculus_values/environment_specific_values/`
  - Clones the Loculus repository at the version specified in `pathoplexus_app/values.yaml`
  - Runs `helm template` for each environment with the correct values hierarchy
  - Provides debug output if templating fails

### Why is this needed?
Currently, we don't have automated checks to ensure our Helm configurations are valid. This could lead to deployment failures that are only discovered when attempting to deploy to an environment. This CI check will catch configuration errors earlier in the development process.

### How it works
1. The workflow triggers on PRs and pushes to main when relevant files change
2. It first discovers all available environments by listing YAML files in `environment_specific_values/`
3. For each environment, it:
   - Checks out both the Pathoplexus and Loculus repositories
   - Runs `helm template` with the three-layer values hierarchy:
     - Base Loculus values
     - Pathoplexus common values
     - Environment-specific values
4. If templating fails, it re-runs with debug output to help diagnose the issue
