### PR TITLE
Revert "feat: Support floats for host age (#492)"

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -787,11 +787,11 @@ defaultOrganismConfig: &defaultOrganismConfig
         header: Specimen processing
       - name: hostAge
         ontology_id: GENEPIO:0001392
-        definition: Age of host (in years) at the time of sampling. Decimal numbers are supported, intended for use with young hosts. 6 months are entered as 0.5 years.
+        definition: Age of host (in years) at the time of sampling.
         guidance: In case of privacy concerns use hostAgeBin.
         example: "79"
         displayName: Host age
-        type: float
+        type: int
         header: Host
         rangeSearch: true
       - name: hostAgeBin


### PR DESCRIPTION
This reverts commit 05f97b8cd2a4d66007db379823656587e39d5adf.

The reason for revert is that certain inputs will break preprocessing.

See https://github.com/loculus-project/loculus/issues/4345
