### PR TITLE
feat: Make authors required

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -610,7 +610,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         definition: "List of authors who should be listed on the sample."
         guidance: "Authors should be separated by semi-colons. Each author's name should be in the format `last name, first name;`. Last name(s) is mandatory, only ASCII alphabetical characters A-Z are allowed."
         example: "Smith, Anna; Perez, Tom J.; Xu,;"
-        desired: true
+        required: true
       - name: authorAffiliations
         displayName: Author affiliations
         generateIndex: true


### PR DESCRIPTION
resolves #541

change `authors` from desired to required

preview: https://preview-make-authors-required.pathoplexus.org

### Screenshot

<img width="922" alt="image" src="https://github.com/user-attachments/assets/ecc94fdf-d248-49a5-a090-78b679bcae05" />

Authors now appears under the required fields.