### PR TITLE
Add initial docs about external linkouts to tools

### DIFF
--- a/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
+++ b/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
@@ -77,4 +77,4 @@ encoding happens after any placeholders are substituted, so `{{[unalignedNucleot
 Multiple placeholders can appear in a single URL, allowing you to pass both
 sequence and metadata downloads to an external tool.
 
-You can create a PR in the [Pathoplexus repository](https://github.com/pathoplexus/pathoplexus) to add your link-out entries to the configuration under a specific organism, or raise an issue to suggest this.
+You can create a PR or issue in the [Pathoplexus repository](https://github.com/pathoplexus/pathoplexus) to suggest adding your link-out entries to the configuration under a specific organism, and we'll consider all suggested new tools.

--- a/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
+++ b/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
@@ -76,4 +76,4 @@ encoding happens after any placeholders are substituted, so `{{[unalignedNucleot
 Multiple placeholders can appear in a single URL, allowing you to pass both
 sequence and metadata downloads to an external tool.
 
-You can create a PR to add your link-out entries to the configuration under a specific organism, or raise an issue to suggest this.
+You can create a PR in the [Pathoplexus repository](https://github.com/pathoplexus/pathoplexus) to add your link-out entries to the configuration under a specific organism, or raise an issue to suggest this.

--- a/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
+++ b/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
@@ -27,6 +27,7 @@ For a tool to be integrated into the Pathoplexus tools menu, it must be able to:
 - Automatically fetch and process the files from these URLs and do something useful with them
 
 When users select your tool from the Tools menu, Pathoplexus will generate download URLs, configured in a way that you specify, then redirect users to your tool with these URLs embedded in the web address. Your tool needs to parse these URLs from its incoming request and retrieve the files directly from Pathoplexus.
+Tools are available on a per-pathogen basis; if a tool will only work with some of the pathogens on Pathoplexus, you can add it to just those. If it will work on all pathogens, you can add it to all of them.
 
 ### Adding your tool to Pathoplexus
 

--- a/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
+++ b/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
@@ -8,7 +8,7 @@ order: 105
 ## Using the Tools menu
 
 The sequence search page contains a **Tools** dropdown that lists external
-applications that can be launched with the sequences in your search query or any that you select. Select some sequences (or just make a search), open the
+applications that can be launched with the sequences in your search query or any that you select. Select some sequences (or execute a search), open the
 dropdown and choose a tool. You will be taken to the tool in question which will be supplied with URLs so that it can seamlessly retrieve the sequences you are looking for from Pathoplexus.
 
 Initial tools allow you to:

--- a/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
+++ b/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
@@ -9,11 +9,15 @@ order: 45
 
 The sequence search page contains a **Tools** dropdown that lists external
 applications that can be launched with the sequences in your search query or any that you select. Select some sequences (or just make a search), open the
-dropdown and choose a tool. You will be taken to the tool in question which will be supplied with URLs so that it can seamlessly retrieve the sequences you are looking for from Pathoplexus
+dropdown and choose a tool. You will be taken to the tool in question which will be supplied with URLs so that it can seamlessly retrieve the sequences you are looking for from Pathoplexus.
+
+Initial tools allow you to:
+- perform QC on sequences with Nextclade and see them on a tree (for some organisms)
+- visualise the geographic distribution of your sequences
 
 ## Configuring a new tool to be added to Pathoplexus
 
-We are interested in adding new useful tools to Pathoplexus.
+We are interested in adding new useful external tools to this menu. If you are a developer of tools interested in having your tool featured here, please read on.
 
 ### Requirements
 

--- a/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
+++ b/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
@@ -72,7 +72,7 @@ Each placeholder can be extended with options:
 
 To ensure parts of the URL are properly URL encoded, wrap them in double curly
 braces. For example `{{my query}}` becomes `my%20query` after processing. This
-encoding happens after any placeholders are substituted, so `{{[unalignedNucleotideSequences]}}` will become a properly URL-encoded URL to access the unaligned nucleotide sequences. You can even doubly-nest `{{}}` syntax where necessary.
+encoding happens after placeholders are substituted, so `{{[unalignedNucleotideSequences]}}` will become a properly URL-encoded URL to access the unaligned nucleotide sequences. You can even doubly-nest `{{}}` syntax where necessary.
 
 Multiple placeholders can appear in a single URL, allowing you to pass both
 sequence and metadata downloads to an external tool.

--- a/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
+++ b/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
@@ -1,0 +1,62 @@
+---
+layout: ../../../layouts/DocLayout.astro
+title: 'Use external tools and suggest new ones'
+order: 45
+---
+
+
+## Using the Tools menu
+
+The sequence search page contains a **Tools** dropdown that lists external
+applications that can be launched with the sequences in your search query or any that you select. Select some sequences (or just make a search), open the
+dropdown and choose a tool. You will be taken to the tool in question which will be supplied with URLs so that it can seamlessly retrieve the sequences you are looking for from Pathoplexus
+
+## Configuring a new tool to be added to Pathoplexus
+
+The list of tools is defined in the `linkOuts` section of the `values.yaml`
+configuration of Pathoplexus.
+
+A link-out entry has the following structure:
+
+```json
+{
+  "name": "My Tool",
+  "url": "http://example.com/analysis?data={{[unalignedNucleotideSequences]}}",
+  "maxNumberOfRecommendedEntries": 100
+}
+```
+
+`name` is displayed in the menu, `url` is a template that may contain
+placeholders and `maxNumberOfRecommendedEntries` is optional. When this value is
+set, users will be warned if they attempt to send more sequences than the limit
+suggests.
+
+### URL template placeholders
+
+The URL template may contain placeholders wrapped in square brackets. They are
+replaced with download links generated for the current search results. Available
+placeholders are:
+
+- `[unalignedNucleotideSequences]` – link to the unaligned FASTA file.
+- `[alignedNucleotideSequences]` – link to the aligned FASTA file.
+- `[metadata]` – link to a metadata table in TSV format.
+
+Each placeholder can be extended with options:
+
+- `:[segment]` – restricts the sequence download to a specific segment, e.g.
+  `[unalignedNucleotideSequences:S]`.
+- `+rich` – include rich FASTA headers when supported, e.g.
+  `[unalignedNucleotideSequences+rich]`.
+- `|format` – request a specific data format such as `json`, e.g.
+  `[metadata|json]`.
+- For metadata, `+col1,col2` can be used to include only
+  certain fields, e.g. `[metadata+country,host]`.
+
+To ensure parts of the URL are properly URL encoded, wrap them in double curly
+braces. For example `{{my query}}` becomes `my%20query` after processing. This
+encoding happens after any placeholders are substituted, so `{{[unalignedNucleotideSequences]}}` will become a properly URL-encoded URL to access the unaligned nucleotide sequences. You can even doubly-nest `{{}}` syntax where necessary.
+
+Multiple placeholders can appear in a single URL, allowing you to pass both
+sequence and metadata downloads to an external tool.
+
+You can create a PR to add your link-out entries to the configuration under a specific organism, or raise an issue to suggest this.

--- a/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
+++ b/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
@@ -67,7 +67,7 @@ Each placeholder can be extended with options:
   `[unalignedNucleotideSequences+rich]`.
 - `|format` – request a specific data format such as `json`, e.g.
   `[metadata|json]`.
-- For metadata, `+col1,col2` can be used to include only
+- For metadata, a comma-separated format like `+col1,col2` can be used to include only
   certain fields, e.g. `[metadata+country,host]`.
 
 To ensure parts of the URL are properly URL encoded, wrap them in double curly

--- a/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
+++ b/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
@@ -17,7 +17,7 @@ Initial tools allow you to:
 
 ## Configuring a new tool to be added to Pathoplexus
 
-We are interested in adding new useful external tools to this menu. If you are a developer of tools interested in having your tool featured here, please read on.
+We are interested in adding new useful external tools to this menu. If you are a tool developer interested in having your tool featured here, please read on.
 
 ### Requirements
 

--- a/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
+++ b/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
@@ -12,7 +12,7 @@ applications that can be launched with the sequences in your search query or any
 dropdown and choose a tool. You will be taken to the tool in question which will be supplied with URLs so that it can seamlessly retrieve the sequences you are looking for from Pathoplexus.
 
 Initial tools allow you to:
-- perform QC on sequences with Nextclade and see them on a tree (for some organisms)
+- perform QC on sequences with Nextclade and see their placement on a phylogenetic tree (only available for some organisms)
 - visualise the geographic distribution of your sequences
 
 ## Configuring a new tool to be added to Pathoplexus

--- a/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
+++ b/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
@@ -1,7 +1,7 @@
 ---
 layout: ../../../layouts/DocLayout.astro
 title: 'Use external tools and suggest new ones'
-order: 45
+order: 105
 ---
 
 

--- a/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
+++ b/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
@@ -26,7 +26,7 @@ For a tool to be integrated into the Pathoplexus tools menu, it must be able to:
 - Accept file URLs as parameters in its web address
 - Automatically fetch and process the files from these URLs and do something useful with them
 
-When users select your tool from the Tools menu, Pathoplexus will generate download URLs, configured in a way that you specify, then redirect users to your tool with these URLs embedded in the web address. Your tool needs to parse these URLs from its incoming request and retrieve the files directly from Pathoplexus.
+When users select your tool from the Tools menu, Pathoplexus will generate download URLs, configured in a way that you specify, then redirect users to your tool with these URLs embedded in the web address. Your tool needs to parse these URLs from the incoming request and retrieve the files directly from Pathoplexus.
 Tools are available on a per-pathogen basis; if a tool will only work with some of the pathogens on Pathoplexus, you can add it to just those. If it will work on all pathogens, you can add it to all of them.
 
 ### Adding your tool to Pathoplexus

--- a/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
+++ b/monorepo/website/src/pages/docs/how-to/use-tools-and-add-new-ones.mdx
@@ -13,6 +13,19 @@ dropdown and choose a tool. You will be taken to the tool in question which will
 
 ## Configuring a new tool to be added to Pathoplexus
 
+We are interested in adding new useful tools to Pathoplexus.
+
+### Requirements
+
+For a tool to be integrated into the Pathoplexus tools menu, it must be able to:
+
+- Accept file URLs as parameters in its web address
+- Automatically fetch and process the files from these URLs and do something useful with them
+
+When users select your tool from the Tools menu, Pathoplexus will generate download URLs, configured in a way that you specify, then redirect users to your tool with these URLs embedded in the web address. Your tool needs to parse these URLs from its incoming request and retrieve the files directly from Pathoplexus.
+
+### Adding your tool to Pathoplexus
+
 The list of tools is defined in the `linkOuts` section of the `values.yaml`
 configuration of Pathoplexus.
 


### PR DESCRIPTION
Adds some initial docs about external tools and how more can be added. We can improve this later.

https://preview-toolsdocs.pathoplexus.org/docs/how-to/use-tools-and-add-new-ones