### PR TITLE
feat(config): add comment field

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1279,7 +1279,7 @@ defaultOrganismConfig: &defaultOrganismConfig
           inputs: {input: nextclade.coverage}
       - name: comment
         displayName: Comment
-        header: "Additional information"
+        header: "Submission details"
         definition: "Any additional comments about the sample or sequence."
     website: &website
       tableColumns:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1277,8 +1277,8 @@ defaultOrganismConfig: &defaultOrganismConfig
           type: percentage
         preprocessing:
           inputs: {input: nextclade.coverage}
-      - name: comments
-        displayName: Comments
+      - name: comment
+        displayName: Comment
         header: "Additional information"
         definition: "Any additional comments about the sample or sequence."
     website: &website
@@ -1311,7 +1311,7 @@ defaultOrganismConfig: &defaultOrganismConfig
       - sequencingProtocol  
       - specimenCollectorSampleId  
       - versionComment
-      - comments  
+      - comment
   preprocessing:
     - &preprocessing
       replicas: 1

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1277,6 +1277,10 @@ defaultOrganismConfig: &defaultOrganismConfig
           type: percentage
         preprocessing:
           inputs: {input: nextclade.coverage}
+      - name: comments
+        displayName: Comments
+        header: "Additional information"
+        definition: "Any additional comments about the sample or sequence."
     website: &website
       tableColumns:
         - sampleCollectionDate
@@ -1306,7 +1310,8 @@ defaultOrganismConfig: &defaultOrganismConfig
       - sequencingInstrument  
       - sequencingProtocol  
       - specimenCollectorSampleId  
-      - versionComment  
+      - versionComment
+      - comments  
   preprocessing:
     - &preprocessing
       replicas: 1


### PR DESCRIPTION
resolves: https://github.com/pathoplexus/pathoplexus/issues/547

copy of https://github.com/pathoplexus/pathoplexus/pull/563

As discussed in https://loculus.slack.com/archives/C05G172HL6L/p1751448536534509?thread_ts=1751446873.936119&cid=C05G172HL6L we should call this field comment

preview: https://preview-anya-notes-field.pathoplexus.org/

<img width="1278" height="612" alt="image" src="https://github.com/user-attachments/assets/e9a93244-3163-470f-8a2a-d55ab7095981" />
<img width="1250" height="1122" alt="image" src="https://github.com/user-attachments/assets/36e93622-ef7f-4360-8bc9-836866c872e0" />

