### PR TITLE
Remove erroneous client:load

### DIFF
--- a/monorepo/website/src/pages/docs/concepts/metadataformat.mdx
+++ b/monorepo/website/src/pages/docs/concepts/metadataformat.mdx
@@ -24,4 +24,4 @@ Please format authors as a string where each author is separated using a semi-co
 
 ## Overview
 
-<MetadataTable client:load />
+<MetadataTable />


### PR DESCRIPTION
Avoid warning

```
You are attempting to render <MetadataTable client:load />, but MetadataTable is an Astro component. Astro components do not render in the client and should not have a hydration directive. Please use a framework component for client rendering.
```