### PR TITLE
Show bank account details uncollapsed

### DIFF
--- a/monorepo/website/src/pages/about/funding.mdx
+++ b/monorepo/website/src/pages/about/funding.mdx
@@ -16,11 +16,8 @@ We welcome donations from individuals.
 
 Our bank account details are as follows. Our account is based in Switzerland and in Swiss Francs (CHF). If your account is in a different currency, we recommend using [Wise](https://wise.com/).
 
-  <details class="bank-details bg-gray-50 p-4 rounded-lg">
-    <summary>
-      <span class="text-sm font-medium">Bank account details (click to expand)</span><br />
-
-        </summary>
+  <div class="bank-details bg-gray-50 p-4 rounded-lg">
+      <span class="text-sm font-medium">Bank account details</span><br />
     <table class="my-3 border-collapse border border-gray-200 rounded-lg">
       <tbody>
         <tr class="bg-gray-50">
@@ -49,7 +46,7 @@ Our bank account details are as follows. Our account is based in Switzerland and
         </tr>
       </tbody>
     </table>
-  </details>
+  </div>
 
 
 


### PR DESCRIPTION
Avoid collapsing bank details by default, see https://preview-details.pathoplexus.org/about/funding