### PR TITLE
feat: Validate all INSDC input accessions with regex, bump all processing versions

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -639,12 +639,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         noInput: true
         perSegment: true
         oneHeader: true
-        preprocessing:
-          function: check_regex
-          inputs:
-            regex_field: insdcAccessionBase
-          args:
-            pattern: "^[A-Z]+[0-9]+$"
       - name: insdcVersion
         displayName: INSDC version
         type: int
@@ -653,12 +647,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         noInput: true
         perSegment: true
         oneHeader: true
-        preprocessing:
-          function: check_regex
-          inputs:
-            regex_field: insdcVersion
-          args:
-            pattern: "^[0-9]+$"
       - name: insdcAccessionFull
         displayName: INSDC accession
         includeInDownloadsByDefault: true
@@ -670,12 +658,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         noInput: true
         perSegment: true
         oneHeader: true
-        preprocessing:
-          function: check_regex
-          inputs:
-            regex_field: insdcAccessionFull
-          args:
-            pattern: '^[A-Z]+[0-9]+\.[0-9]+$'
       - name: bioprojectAccession
         displayName: BioProject accession
         customDisplay:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1219,7 +1219,8 @@ defaultOrganismConfig: &defaultOrganismConfig
           inputs:
             regex_field: insdcRawReadsAccession
           args:
-            pattern: "^(E|D|S)RR[0-9]{6,}$"
+            # NCBI can output comma-separated lists of SRR accessions
+            pattern: "^(E|D|S)RR[0-9]{6,}(,(E|D|S)RR[0-9]{6,})*$"
       - name: totalSnps
         type: int
         header: "Alignment and QC metrics"

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1220,7 +1220,9 @@ defaultOrganismConfig: &defaultOrganismConfig
             regex_field: insdcRawReadsAccession
           args:
             # NCBI can output comma-separated lists of SRR accessions
-            pattern: "^(E|D|S)RR[0-9]{6,}(,(E|D|S)RR[0-9]{6,})*$"
+            # Also accept ERS/SRS for now, as NCBI virus occasionally sends those
+            # See https://github.com/ncbi/datasets/issues/516
+            pattern: "^(E|D|S)R(R|S)[0-9]{6,}(,(E|D|S)R(R|S)[0-9]{6,})*$"
       - name: totalSnps
         type: int
         header: "Alignment and QC metrics"

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -639,6 +639,12 @@ defaultOrganismConfig: &defaultOrganismConfig
         noInput: true
         perSegment: true
         oneHeader: true
+        preprocessing:
+          function: check_regex
+          inputs:
+            regex_field: insdcAccessionBase
+          args:
+            pattern: "^[A-Z]+[0-9]+$"
       - name: insdcVersion
         displayName: INSDC version
         type: int
@@ -647,6 +653,12 @@ defaultOrganismConfig: &defaultOrganismConfig
         noInput: true
         perSegment: true
         oneHeader: true
+        preprocessing:
+          function: check_regex
+          inputs:
+            regex_field: insdcVersion
+          args:
+            pattern: "^[0-9]+$"
       - name: insdcAccessionFull
         displayName: INSDC accession
         includeInDownloadsByDefault: true
@@ -658,6 +670,12 @@ defaultOrganismConfig: &defaultOrganismConfig
         noInput: true
         perSegment: true
         oneHeader: true
+        preprocessing:
+          function: check_regex
+          inputs:
+            regex_field: insdcAccessionFull
+          args:
+            pattern: '^[A-Z]+[0-9]+\.[0-9]+$'
       - name: bioprojectAccession
         displayName: BioProject accession
         customDisplay:
@@ -668,6 +686,12 @@ defaultOrganismConfig: &defaultOrganismConfig
         guidance: "Only add this field if you want your sequences to be deposited into an existing public BioProject in the INSDC. If you do not have a bioproject, leave this field blank - we will create a BioProject for you on submission of your consensus sequence."
         definition: "Accession of public BioProject in the INSDC your consensus sequences should be uploaded to."
         example: "PRJNA123456"
+        preprocessing:
+          function: check_regex
+          inputs:
+            regex_field: insdcAccessionFull
+          args:
+            pattern: "^PRJ(E|D|N)[A-Z][0-9]+$"
       - name: biosampleAccession
         displayName: BioSample accession
         customDisplay:
@@ -679,6 +703,12 @@ defaultOrganismConfig: &defaultOrganismConfig
         definition: "Accession of corresponding public BioSample of the raw reads in the INSDC"
         example: "SAMN12345678"
         oneHeader: true
+        preprocessing:
+          function: check_regex
+          inputs:
+            regex_field: insdcAccessionFull
+          args:
+            pattern: "^SAM(E|D|N)[A-Z]?[0-9]+$"
       - name: gcaAccession
         displayName: GCA accession
         customDisplay:
@@ -687,6 +717,12 @@ defaultOrganismConfig: &defaultOrganismConfig
         header: "INSDC"
         noInput: true
         oneHeader: true
+        preprocessing:
+          function: check_regex
+          inputs:
+            regex_field: insdcAccessionFull
+          args:
+            pattern: '^GCA_[0-9]{9}\.[0-9]+$'
       - name: cultureId
         displayName: Culture ID
         header: Sample details
@@ -1202,6 +1238,12 @@ defaultOrganismConfig: &defaultOrganismConfig
         ingest: ncbiSraAccessions
         guidance: "Only add this field if you have already submitted raw reads to the INSDC, read more at https://pathoplexus.org/docs/how-to/upload-sequences."
         definition: "Accession of corresponding raw reads in the INSDC, e.g. SRR27477368"
+        preprocessing:
+          function: check_regex
+          inputs:
+            regex_field: insdcRawReadsAccession
+          args:
+            pattern: "^(E|D|S)RR[0-9]{6,}$"
       - name: totalSnps
         type: int
         header: "Alignment and QC metrics"
@@ -1324,16 +1366,8 @@ defaultOrganismConfig: &defaultOrganismConfig
         nextclade_dataset_name: nextstrain/ebola/zaire
         genes: [NP, VP35, VP40, GP, sGP, ssGP, VP30, VP24, L]
         batch_size: 100
-    # - <<: *preprocessing
-    #   version: 11
-    #   image: ghcr.io/loculus-project/preprocessing-nextclade
-    #   args:
-    #     - "prepro"
-    #   configFile: &preprocessingConfigFile
-    #     log_level: DEBUG
-    #     nextclade_dataset_name: nextstrain/ebola/zaire
-    #     genes: [NP, VP35, VP40, GP, sGP, ssGP, VP30, VP24, L]
-    #     batch_size: 100
+    - <<: *preprocessing
+      version: 11
   ingest: &ingest
     image: ghcr.io/loculus-project/ingest
     configFile: &ingestConfigFile
@@ -1376,12 +1410,12 @@ organisms:
           <<: *preprocessingConfigFile
           nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/ebola/data_output
           nextclade_dataset_name: nextstrain/ebola/zaire
-      # - <<: *preprocessing
-      #   version: 11
-      #   configFile:
-      #     <<: *preprocessingConfigFile
-      #     nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/ebola/data_output
-      #     nextclade_dataset_name: nextstrain/ebola/zaire
+      - <<: *preprocessing
+        version: 11
+        configFile:
+          <<: *preprocessingConfigFile
+          nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/ebola/data_output
+          nextclade_dataset_name: nextstrain/ebola/zaire
   ebola-sudan:
     <<: *defaultOrganismConfig
     schema:
@@ -1414,12 +1448,12 @@ organisms:
           <<: *preprocessingConfigFile
           nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/ebola/data_output
           nextclade_dataset_name: nextstrain/ebola/sudan
-      # - <<: *preprocessing
-      #   version: 11
-      #   configFile:
-      #     <<: *preprocessingConfigFile
-      #     nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/ebola/data_output
-      #     nextclade_dataset_name: nextstrain/ebola/sudan
+      - <<: *preprocessing
+        version: 11
+        configFile:
+          <<: *preprocessingConfigFile
+          nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/ebola/data_output
+          nextclade_dataset_name: nextstrain/ebola/sudan
     ingest:
       <<: *ingest
       configFile:
@@ -1510,13 +1544,13 @@ organisms:
           nextclade_dataset_name: nextstrain/wnv/all-lineages
           nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/wnv/data_output
           genes: [capsid, prM, env, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
-      # - <<: *preprocessing
-      #   version: 11
-      #   configFile:
-      #     <<: *preprocessingConfigFile
-      #     nextclade_dataset_name: nextstrain/wnv/all-lineages
-      #     nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/wnv/data_output
-      #     genes: [capsid, prM, env, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
+      - <<: *preprocessing
+        version: 11
+        configFile:
+          <<: *preprocessingConfigFile
+          nextclade_dataset_name: nextstrain/wnv/all-lineages
+          nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/wnv/data_output
+          genes: [capsid, prM, env, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
     ingest:
       <<: *ingest
       configFile:
@@ -1611,14 +1645,14 @@ organisms:
           nextclade_dataset_name: nextstrain/cchfv/linked
           nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/cornelius-cchfv/data_output
           genes: [RdRp, GPC, NP]
-      # - <<: *preprocessing
-      #   version: 11
-      #   configFile:
-      #     <<: *preprocessingConfigFile
-      #     log_level: DEBUG
-      #     nextclade_dataset_name: nextstrain/cchfv/linked
-      #     nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/cornelius-cchfv/data_output
-      #     genes: [RdRp, GPC, NP]
+      - <<: *preprocessing
+        version: 11
+        configFile:
+          <<: *preprocessingConfigFile
+          log_level: DEBUG
+          nextclade_dataset_name: nextstrain/cchfv/linked
+          nextclade_dataset_server: https://raw.githubusercontent.com/nextstrain/nextclade_data/cornelius-cchfv/data_output
+          genes: [RdRp, GPC, NP]
     ingest:
       <<: *ingest
       configFile:
@@ -2574,13 +2608,13 @@ organisms:
           nextclade_dataset_name: "nextstrain/hmpv/all-clades/NC_039199"
           nextclade_dataset_tag: "2025-04-25--12-24-24Z"
           genes: [ "F", "G", "L", "M", "N", "M2-1", "M2-2", "P", "SH" ]
-      # - <<: *preprocessing
-      #   version: 11
-      #   configFile:
-      #     <<: *preprocessingConfigFile
-      #     nextclade_dataset_name: "nextstrain/hmpv/all-clades/NC_039199"
-      #     nextclade_dataset_tag: "2025-04-25--12-24-24Z"
-      #     genes: [ "F", "G", "L", "M", "N", "M2-1", "M2-2", "P", "SH" ]
+      - <<: *preprocessing
+        version: 11
+        configFile:
+          <<: *preprocessingConfigFile
+          nextclade_dataset_name: "nextstrain/hmpv/all-clades/NC_039199"
+          nextclade_dataset_tag: "2025-04-25--12-24-24Z"
+          genes: [ "F", "G", "L", "M", "N", "M2-1", "M2-2", "P", "SH" ]
     ingest:
       <<: *ingest
       configFile:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -671,7 +671,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         preprocessing:
           function: check_regex
           inputs:
-            regex_field: insdcAccessionFull
+            regex_field: bioprojectAccession
           args:
             pattern: "^PRJ(E|D|N)[A-Z][0-9]+$"
       - name: biosampleAccession
@@ -688,7 +688,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         preprocessing:
           function: check_regex
           inputs:
-            regex_field: insdcAccessionFull
+            regex_field: biosampleAccession
           args:
             pattern: "^SAM(E|D|N)[A-Z]?[0-9]+$"
       - name: gcaAccession
@@ -699,12 +699,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         header: "INSDC"
         noInput: true
         oneHeader: true
-        preprocessing:
-          function: check_regex
-          inputs:
-            regex_field: insdcAccessionFull
-          args:
-            pattern: '^GCA_[0-9]{9}\.[0-9]+$'
       - name: cultureId
         displayName: Culture ID
         header: Sample details


### PR DESCRIPTION
We can use the regex validation for more input fields than just GISAID.

This PR adds regex validation to all input accessions, to INSDC accessions as well. This also makes bumping of preprocessing version to 11 for all organisms necessary.

The accession regexes are from here:
https://ena-docs.readthedocs.io/en/latest/submit/general-guide/accessions.html

<img width="868" height="618" alt="image" src="https://github.com/user-attachments/assets/e894a002-1b75-4323-bbd3-47505b565fc6" />

This also shows how annoying bumping prepro versions is config wise - this doesn't scale. Each organism means more lines to add/remove for each config bump: error prone, annoying etc.

### Testing

I've tested on staging that the validations pass (had to make changes: accept lists of raw reads accessions and ERS)