### PR TITLE
Add bovine respiratory syncytial virus minimizers for broader ingest coverage

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2374,7 +2374,7 @@ organisms:
           nextclade_dataset_name: "nextstrain/rsv/a/EPI_ISL_412866"
           nextclade_dataset_tag: "2024-11-27--02-51-00Z"
           require_nextclade_sort_match: true
-          minimizer_url: "https://anna-parker.github.io/InfluenzaAReferenceDB/results/rsv_segments.minimizer.json"
+          minimizer_url: "https://github.com/alejandra-gonzalezsanchez/loculus-evs/blob/master/rsv_minimizer-index.json"
           accepted_dataset_matches: 
             - rsv-a
           genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
@@ -2393,8 +2393,8 @@ organisms:
     ingest:
       <<: *ingest
       configFile:
-        taxon_id: 11250
-        minimizer_index: "https://anna-parker.github.io/InfluenzaAReferenceDB/results/rsv_segments.minimizer.json"
+        taxon_id: 1868215
+        minimizer_index: "https://github.com/alejandra-gonzalezsanchez/loculus-evs/blob/master/rsv_minimizer-index.json"
         minimizer_parser: # Name of each '_' - separated entry in the minimizer index
           - subtype
         metadata_filter: 
@@ -2489,7 +2489,7 @@ organisms:
           nextclade_dataset_name: "nextstrain/rsv/b/EPI_ISL_1653999"
           nextclade_dataset_tag: "2025-03-04--17-31-25Z"
           require_nextclade_sort_match: true
-          minimizer_url: "https://anna-parker.github.io/InfluenzaAReferenceDB/results/rsv_segments.minimizer.json"
+          minimizer_url: "https://github.com/alejandra-gonzalezsanchez/loculus-evs/blob/master/rsv_minimizer-index.json"
           accepted_dataset_matches: 
             - rsv-b
           genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
@@ -2508,8 +2508,8 @@ organisms:
     ingest:
       <<: *ingest
       configFile:
-        taxon_id: 11250
-        minimizer_index: "https://anna-parker.github.io/InfluenzaAReferenceDB/results/rsv_segments.minimizer.json"
+        taxon_id: 1868215
+        minimizer_index: "https://github.com/alejandra-gonzalezsanchez/loculus-evs/blob/master/rsv_minimizer-index.json"
         minimizer_parser: # Name of each '_' - separated entry in the minimizer index
           - subtype
         metadata_filter: 


### PR DESCRIPTION
Added new minimizers for RSV, following the previous structure, and included a bovine RSV reference.

Minimizers are now based on:

- "rsv-a" = PP109421.1 hRSV/A/England/397/2017 (EPI_ISL_412866)
- "rsv-b" = OP975389.1 hRSV/B/Australia/VIC-RCH056/2019 (EPI_ISL_1653999)
- "brsv" = NC_038272.1 Bovine respiratory syncytial virus ATCC51908, complete genome

The taxon_id for RSV-A and RSV-B ingest has been updated to 1868215 (Orthopneumovirus), which includes:
- Orthopneumovirus bovis (includes the 'Respiratory syncytial virus', txid: 12814)
- Orthopneumovirus hominis
- Orthopneumovirus muris 

This change ensures proper handling of cases where sequences are assigned to [Respiratory syncytial virus](https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Info&id=12814&lvl=3&p=has_linkout&p=blast_url&p=genome_blast&lin=f&keep=1&srchmode=1&unlock) (taxon id = 12814, under [Bovine orthopneumovirus](https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Undef&id=11246&lvl=3&p=has_linkout&p=blast_url&p=genome_blast&keep=1&srchmode=1&unlock)), but actually originate from [human respiratory syncytial virus](https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi?mode=Tree&id=3049954&lvl=3&p=has_linkout&p=blast_url&p=genome_blast&lin=f&keep=1&srchmode=1&unlock).
