### PR TITLE
Use ENA to view GCA accessions

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -733,7 +733,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: GCA accession
         customDisplay:
           type: link
-          url: "https://www.ncbi.nlm.nih.gov/datasets/genome/__value__"
+          url: "https://www.ebi.ac.uk/ena/browser/view/__value__"
         header: "INSDC"
         orderOnDetailsPage: 1100
         noInput: true


### PR DESCRIPTION
See issue: https://github.com/pathoplexus/ena-submission/issues/80#issuecomment-3164182804 - Genbank is planning to no longer display GCAs and they are no longer being propagated - therefore we should link to ENA for viewing the assembly GCA accessions

Sadly we have no GCA examples in the ingested data (probably as we ingest from NCBI virus) 