### PR TITLE
Update RSV to ingest at a higher taxon:  1868215 and include b-rsv in minimizers

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2509,7 +2509,7 @@ organisms:
           nextclade_dataset_name: "nextstrain/rsv/a/EPI_ISL_412866"
           nextclade_dataset_tag: "2024-11-27--02-51-00Z"
           require_nextclade_sort_match: true
-          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizer-creator/rsv/minimizer.json"
+          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
           accepted_dataset_matches: 
             - rsv-a
           genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
@@ -2521,7 +2521,7 @@ organisms:
       #     nextclade_dataset_name: "nextstrain/rsv/a/EPI_ISL_412866"
       #     nextclade_dataset_tag: "2024-11-27--02-51-00Z"
       #     require_nextclade_sort_match: true
-      #     minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizer-creator/rsv/minimizer.json"
+      #     minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
       #     accepted_dataset_matches: 
       #       - rsv-a
       #     genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
@@ -2529,7 +2529,7 @@ organisms:
       <<: *ingest
       configFile:
         taxon_id: 1868215
-        minimizer_index: "https://loculus-project.github.io/nextclade-sort-minimizer-creator/rsv/minimizer.json"
+        minimizer_index: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
         minimizer_parser: # Name of each '_' - separated entry in the minimizer index
           - subtype
         metadata_filter: 
@@ -2626,7 +2626,7 @@ organisms:
           nextclade_dataset_name: "nextstrain/rsv/b/EPI_ISL_1653999"
           nextclade_dataset_tag: "2025-03-04--17-31-25Z"
           require_nextclade_sort_match: true
-          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizer-creator/rsv/minimizer.json"
+          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
           accepted_dataset_matches: 
             - rsv-b
           genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
@@ -2638,7 +2638,7 @@ organisms:
       #     nextclade_dataset_name: "nextstrain/rsv/b/EPI_ISL_1653999"
       #     nextclade_dataset_tag: "2025-03-04--17-31-25Z"
       #     require_nextclade_sort_match: true
-      #     minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizer-creator/rsv/minimizer.json"
+      #     minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
       #     accepted_dataset_matches: 
       #       - rsv-b
       #     genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
@@ -2646,7 +2646,7 @@ organisms:
       <<: *ingest
       configFile:
         taxon_id: 1868215
-        minimizer_index: "https://loculus-project.github.io/nextclade-sort-minimizer-creator/rsv/minimizer.json"
+        minimizer_index: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
         minimizer_parser: # Name of each '_' - separated entry in the minimizer index
           - subtype
         metadata_filter: 

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2509,7 +2509,7 @@ organisms:
           nextclade_dataset_name: "nextstrain/rsv/a/EPI_ISL_412866"
           nextclade_dataset_tag: "2024-11-27--02-51-00Z"
           require_nextclade_sort_match: true
-          minimizer_url: "https://anna-parker.github.io/InfluenzaAReferenceDB/results/rsv_segments.minimizer.json"
+          minimizer_url: "https://github.com/alejandra-gonzalezsanchez/loculus-evs/blob/master/rsv_minimizer-index.json"
           accepted_dataset_matches: 
             - rsv-a
           genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
@@ -2528,8 +2528,8 @@ organisms:
     ingest:
       <<: *ingest
       configFile:
-        taxon_id: 11250
-        minimizer_index: "https://anna-parker.github.io/InfluenzaAReferenceDB/results/rsv_segments.minimizer.json"
+        taxon_id: 1868215
+        minimizer_index: "https://github.com/alejandra-gonzalezsanchez/loculus-evs/blob/master/rsv_minimizer-index.json"
         minimizer_parser: # Name of each '_' - separated entry in the minimizer index
           - subtype
         metadata_filter: 
@@ -2626,7 +2626,7 @@ organisms:
           nextclade_dataset_name: "nextstrain/rsv/b/EPI_ISL_1653999"
           nextclade_dataset_tag: "2025-03-04--17-31-25Z"
           require_nextclade_sort_match: true
-          minimizer_url: "https://anna-parker.github.io/InfluenzaAReferenceDB/results/rsv_segments.minimizer.json"
+          minimizer_url: "https://github.com/alejandra-gonzalezsanchez/loculus-evs/blob/master/rsv_minimizer-index.json"
           accepted_dataset_matches: 
             - rsv-b
           genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
@@ -2645,8 +2645,8 @@ organisms:
     ingest:
       <<: *ingest
       configFile:
-        taxon_id: 11250
-        minimizer_index: "https://anna-parker.github.io/InfluenzaAReferenceDB/results/rsv_segments.minimizer.json"
+        taxon_id: 1868215
+        minimizer_index: "https://github.com/alejandra-gonzalezsanchez/loculus-evs/blob/master/rsv_minimizer-index.json"
         minimizer_parser: # Name of each '_' - separated entry in the minimizer index
           - subtype
         metadata_filter: 

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2509,7 +2509,7 @@ organisms:
           nextclade_dataset_name: "nextstrain/rsv/a/EPI_ISL_412866"
           nextclade_dataset_tag: "2024-11-27--02-51-00Z"
           require_nextclade_sort_match: true
-          minimizer_url: "https://github.com/alejandra-gonzalezsanchez/loculus-evs/blob/master/rsv_minimizer-index.json"
+          minimizer_url: "https://loculus.github.io/loculus-project/nextclade-sort-minimizer-creator/rsv/minimizer.json"
           accepted_dataset_matches: 
             - rsv-a
           genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
@@ -2521,7 +2521,7 @@ organisms:
       #     nextclade_dataset_name: "nextstrain/rsv/a/EPI_ISL_412866"
       #     nextclade_dataset_tag: "2024-11-27--02-51-00Z"
       #     require_nextclade_sort_match: true
-      #     minimizer_url: "https://anna-parker.github.io/InfluenzaAReferenceDB/results/rsv_segments.minimizer.json"
+      #     minimizer_url: "https://loculus.github.io/loculus-project/nextclade-sort-minimizer-creator/rsv/minimizer.json"
       #     accepted_dataset_matches: 
       #       - rsv-a
       #     genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
@@ -2529,7 +2529,7 @@ organisms:
       <<: *ingest
       configFile:
         taxon_id: 1868215
-        minimizer_index: "https://github.com/alejandra-gonzalezsanchez/loculus-evs/blob/master/rsv_minimizer-index.json"
+        minimizer_index: "https://loculus.github.io/loculus-project/nextclade-sort-minimizer-creator/rsv/minimizer.json"
         minimizer_parser: # Name of each '_' - separated entry in the minimizer index
           - subtype
         metadata_filter: 
@@ -2626,7 +2626,7 @@ organisms:
           nextclade_dataset_name: "nextstrain/rsv/b/EPI_ISL_1653999"
           nextclade_dataset_tag: "2025-03-04--17-31-25Z"
           require_nextclade_sort_match: true
-          minimizer_url: "https://github.com/alejandra-gonzalezsanchez/loculus-evs/blob/master/rsv_minimizer-index.json"
+          minimizer_url: "https://loculus.github.io/loculus-project/nextclade-sort-minimizer-creator/rsv/minimizer.json"
           accepted_dataset_matches: 
             - rsv-b
           genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
@@ -2638,7 +2638,7 @@ organisms:
       #     nextclade_dataset_name: "nextstrain/rsv/b/EPI_ISL_1653999"
       #     nextclade_dataset_tag: "2025-03-04--17-31-25Z"
       #     require_nextclade_sort_match: true
-      #     minimizer_url: "https://anna-parker.github.io/InfluenzaAReferenceDB/results/rsv_segments.minimizer.json"
+      #     minimizer_url: "https://loculus.github.io/loculus-project/nextclade-sort-minimizer-creator/rsv/minimizer.json"
       #     accepted_dataset_matches: 
       #       - rsv-b
       #     genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
@@ -2646,7 +2646,7 @@ organisms:
       <<: *ingest
       configFile:
         taxon_id: 1868215
-        minimizer_index: "https://github.com/alejandra-gonzalezsanchez/loculus-evs/blob/master/rsv_minimizer-index.json"
+        minimizer_index: "https://loculus.github.io/loculus-project/nextclade-sort-minimizer-creator/rsv/minimizer.json"
         minimizer_parser: # Name of each '_' - separated entry in the minimizer index
           - subtype
         metadata_filter: 

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2509,7 +2509,7 @@ organisms:
           nextclade_dataset_name: "nextstrain/rsv/a/EPI_ISL_412866"
           nextclade_dataset_tag: "2024-11-27--02-51-00Z"
           require_nextclade_sort_match: true
-          minimizer_url: "https://loculus.github.io/loculus-project/nextclade-sort-minimizer-creator/rsv/minimizer.json"
+          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizer-creator/rsv/minimizer.json"
           accepted_dataset_matches: 
             - rsv-a
           genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
@@ -2521,7 +2521,7 @@ organisms:
       #     nextclade_dataset_name: "nextstrain/rsv/a/EPI_ISL_412866"
       #     nextclade_dataset_tag: "2024-11-27--02-51-00Z"
       #     require_nextclade_sort_match: true
-      #     minimizer_url: "https://loculus.github.io/loculus-project/nextclade-sort-minimizer-creator/rsv/minimizer.json"
+      #     minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizer-creator/rsv/minimizer.json"
       #     accepted_dataset_matches: 
       #       - rsv-a
       #     genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
@@ -2529,7 +2529,7 @@ organisms:
       <<: *ingest
       configFile:
         taxon_id: 1868215
-        minimizer_index: "https://loculus.github.io/loculus-project/nextclade-sort-minimizer-creator/rsv/minimizer.json"
+        minimizer_index: "https://loculus-project.github.io/nextclade-sort-minimizer-creator/rsv/minimizer.json"
         minimizer_parser: # Name of each '_' - separated entry in the minimizer index
           - subtype
         metadata_filter: 
@@ -2626,7 +2626,7 @@ organisms:
           nextclade_dataset_name: "nextstrain/rsv/b/EPI_ISL_1653999"
           nextclade_dataset_tag: "2025-03-04--17-31-25Z"
           require_nextclade_sort_match: true
-          minimizer_url: "https://loculus.github.io/loculus-project/nextclade-sort-minimizer-creator/rsv/minimizer.json"
+          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizer-creator/rsv/minimizer.json"
           accepted_dataset_matches: 
             - rsv-b
           genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
@@ -2638,7 +2638,7 @@ organisms:
       #     nextclade_dataset_name: "nextstrain/rsv/b/EPI_ISL_1653999"
       #     nextclade_dataset_tag: "2025-03-04--17-31-25Z"
       #     require_nextclade_sort_match: true
-      #     minimizer_url: "https://loculus.github.io/loculus-project/nextclade-sort-minimizer-creator/rsv/minimizer.json"
+      #     minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizer-creator/rsv/minimizer.json"
       #     accepted_dataset_matches: 
       #       - rsv-b
       #     genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
@@ -2646,7 +2646,7 @@ organisms:
       <<: *ingest
       configFile:
         taxon_id: 1868215
-        minimizer_index: "https://loculus.github.io/loculus-project/nextclade-sort-minimizer-creator/rsv/minimizer.json"
+        minimizer_index: "https://loculus-project.github.io/nextclade-sort-minimizer-creator/rsv/minimizer.json"
         minimizer_parser: # Name of each '_' - separated entry in the minimizer index
           - subtype
         metadata_filter: 


### PR DESCRIPTION
Reopened PR by @alejandra-gonzalezsanchez 

Preview: https://preview-rsv-minimizers.pathoplexus.org/

Minimizers are now based on:

- "rsv-a" = PP109421.1 hRSV/A/England/397/2017 (EPI_ISL_412866)
- "rsv-b" = OP975389.1 hRSV/B/Australia/VIC-RCH056/2019 (EPI_ISL_1653999)
- "brsv" = NC_038272.1 Bovine respiratory syncytial virus ATCC51908, complete genome
- "mrsv" = NC_025344.1 Orthopneumovirus muris - Pneumovirus dog/Bari/100-12/ITA/2012, complete genome

Ingest taxon_id for RSV-A and RSV-B ingest has been updated to 1868215 (Orthopneumovirus), which includes:
- Orthopneumovirus bovis (includes the 'Respiratory syncytial virus', txid: 12814)
- Orthopneumovirus hominis
- Orthopneumovirus muris 

## TODO - Testing
- [ ] ensure submission on preview + search works well -> lets do this on staging
- [x] switch to using https://github.com/loculus-project/nextclade-sort-minimizer-creator/blob/main/rsv/minimizer.json (hosted on github pages)
- [x] get some numbers: are any sequences labeled as rsv-a/rsv-b now excluded as labeled bovine? -> see numbers below, only 2 and these can be ignored
- [x] Of new bovine sequences labeled as rsv-a/rsv-b how many have human as host? How do these sequences look on a tree? -> almost all have a human host (or are unknown, see data below). In nextclade most align very well and tree looks very good!

### New RSV-A
<img width="2494" height="1420" alt="image" src="https://github.com/user-attachments/assets/5e700f3f-82ab-4861-86ca-f5aa4a535427" />

### New RSV-B
<img width="2494" height="1420" alt="image" src="https://github.com/user-attachments/assets/c5daf90d-0015-448a-a18d-115586a36101" />


## Numbers
There are 5427 new sequences, of these 4539 can be sorted using the new minimizer. We identify (2325 - rsv-a, 1335- rsv-b, 879 - bovine-rsv) using the minimizer. 
- Different dataset for HH979092.1: old=rsv-a, new=nan -> this actually doesn't matter as the alignment fails due to the sequence being too short (Fast view with Fast sequence view with: http://clades.nextstrain.org/?input-fasta=https://www.ebi.ac.uk/ena/browser/api/fasta/HH979092.1&dataset=rsv-a) 
- Different dataset for OQ941681.1: old=rsv-b, new=rsv-a. This is a very highly mutated sequence see placement in rsv-a and rsv-b - but it does have slightly less mutations from rsv-b

### Code snippets

Run the ingest pipeline using the two configs and compare the output:

```
import pandas as pd
import numpy as np 
from Bio import SeqIO

file_old = "sort_results.tsv"
file_new = "sort_results_with_bovine.tsv"

df_old = pd.read_csv(file_old, sep="\t", usecols=["seqName", "dataset"])
df_new = pd.read_csv(file_new, sep="\t", usecols=["seqName", "dataset"])

old_seqs = df_old["seqName"].dropna().drop_duplicates()
new_seqs = df_new["seqName"].dropna().drop_duplicates()

only_old = set(old_seqs) - set(new_seqs)
print("only in old:", only_old)
only_new = set(new_seqs) - set(old_seqs)
print("only in new:", len(only_new))

#only in old: set()
#only in new: 5427

for seq in old_seqs:
    old_val = df_old.loc[df_old["seqName"].eq(seq), "dataset"].iloc[0] if (df_old["seqName"] == seq).any() else np.nan
    new_val = df_new.loc[df_new["seqName"].eq(seq), "dataset"].iloc[0] if (df_new["seqName"] == seq).any() else np.nan

    # Skip if both NaN; otherwise report if different
    if not (pd.isna(old_val) and pd.isna(new_val)) and (old_val != new_val):
        print(f"Different dataset for {seq}: old={old_val}, new={new_val}")

# Different dataset for OQ941681.1: old=rsv-b, new=rsv-a
# Different dataset for HH979092.1: old=rsv-a, new=nan

sub = df_new[df_new["seqName"].isin(only_new)].drop_duplicates(subset=["seqName"])

new_rsv_a  = set(sub.loc[sub["dataset"] == "rsv-a", "seqName"])
new_rsv_b  = set(sub.loc[sub["dataset"] == "rsv-b", "seqName"])
new_bovine = set(sub.loc[sub["dataset"] == "bovine-rsv", "seqName"])
new_murine = set(sub.loc[sub["dataset"] == "murine-rsv", "seqName"])

len(new_rsv_a), len(new_rsv_b), len(new_bovine), len(new_murine)
# (2325, 1335, 879, 66)

metadata = "metadata_post_rename.tsv"
df_metadata = pd.read_csv(metadata, sep="\t")
filtered = df_metadata[df_metadata["genbankAccession"].isin(new_rsv_a)]
host_counts = filtered["ncbiHostName"].value_counts(dropna=False)
print(host_counts)

# ncbiHostName
# Homo sapiens       1684
# NaN                 639
# Pholidota             1
# Pan troglodytes       1
# Name: count, dtype: int64


df_metadata = pd.read_csv(metadata, sep="\t")
filtered = df_metadata[df_metadata["genbankAccession"].isin(new_rsv_b)]
host_counts = filtered["ncbiHostName"].value_counts(dropna=False)
print(host_counts)

# ncbiHostName
# Homo sapiens       1078
# NaN                 251
# Pan troglodytes       6
# Name: count, dtype: int64

input_fa  = "genomic.fna"
output_fa = "new_rsv_a.fasta"


def keep_record(rec, keep):
    return rec.id in keep

count = SeqIO.write((r for r in SeqIO.parse(input_fa, "fasta") if keep_record(r, new_rsv_a)), output_fa, "fasta")
print(f"Wrote {count} records to {output_fa}")
```
