### PR TITLE
Drop unused fields

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -957,7 +957,6 @@ defaultOrganismConfig: &defaultOrganismConfig
       - name: exposureSetting
         ontology_id: GENEPIO:0001428
         definition: The setting or event leading to exposure.
-        guidance: Select the host exposure setting(s) from the pick list provided in the template. If a desired term is missing, contact the curation team.
         example: Healthcare Setting [GENEPIO:0100201]
         displayName: Exposure setting
         header: Host

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -947,15 +947,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Canada, Vancouver; USA, Seattle; Italy, Milan
         displayName: Travel history
         header: Host
-        orderOnDetailsPage: 1760
-      - name: exposureEvent
-        ontology_id: GENEPIO:0001417
-        definition: Event leading to exposure.
-        guidance: "You can use the look-up service: https://www.ebi.ac.uk/ols4/ontologies/ecto to select a value."
-        example: Mass Gathering [GENEPIO:0100237]
-        displayName: Exposure event
-        header: Host
-        orderOnDetailsPage: 1780
       - name: hostRole
         ontology_id: GENEPIO:0001419
         definition: The role of the host in relation to the exposure setting.
@@ -965,7 +956,8 @@ defaultOrganismConfig: &defaultOrganismConfig
         orderOnDetailsPage: 1800
       - name: exposureSetting
         ontology_id: GENEPIO:0001428
-        definition: The setting leading to exposure.
+        definition: The setting or event leading to exposure.
+        guidance: Select the host exposure setting(s) from the pick list provided in the template. If a desired term is missing, contact the curation team.
         example: Healthcare Setting [GENEPIO:0100201]
         displayName: Exposure setting
         header: Host
@@ -983,13 +975,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: COVID-19
         displayName: Previous infection (disease)
         header: Host
-        orderOnDetailsPage: 1860
-      - name: previousInfectionOrganism
-        definition: The name of the pathogen causing the disease previously experienced by the host.
-        example: Sudden Acute Respiratory Syndrome Coronavirus 2 (SARS-CoV-2)
-        displayName: Previous infection (organism)
-        header: Host
-        orderOnDetailsPage: 1880
       - name: hostVaccinationStatus
         ontology_id: GENEPIO:0001404
         definition: The vaccination status of the host (fully vaccinated, partially vaccinated, or not vaccinated) in relation to the sequenced pathogen.
@@ -1096,15 +1081,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: Nanostripper 1.2.3
         displayName: Dehosting method
         header: Sequencing
-        orderOnDetailsPage: 2220
-      - name: assemblyReferenceGenomeAccession
-        ontology_id: GENEPIO:0001485
-        definition: A persistent, unique identifier of a genome database entry.
-        guidance: Provide the INSDC accession number of the reference genome used for mapping/assembly.
-        example: NC_045512.2
-        displayName: Reference genome accession
-        header: Sequencing
-        orderOnDetailsPage: 2250
       - name: consensusSequenceSoftwareName
         ontology_id: GENEPIO:0001463
         definition: The name of software used to generate the consensus sequence.
@@ -1139,46 +1115,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Breadth of coverage
         type: int
         header: Sequencing
-        orderOnDetailsPage: 2320
-      - name: qualityControlMethodName
-        ontology_id: GENEPIO:0100557
-        definition: The name of the method used to assess whether a sequence passed a predetermined quality control threshold.
-        guidance: Method names can be provided as the name of a pipeline or a link to a GitHub repository. Multiple methods should be listed and separated by a semi-colon.
-        example: ncov-tools
-        displayName: Quality control method name
-        header: Sequencing
-        orderOnDetailsPage: 2340
-      - name: qualityControlMethodVersion
-        ontology_id: GENEPIO:0100558
-        definition: The version number of the method used to assess whether a sequence passed a predetermined quality control threshold.
-        guidance: If multiple methods were used, record the version numbers in the same order as the method names. Separate the version numbers using a semi-colon.
-        example: "1.2.3"
-        displayName: Quality control method version
-        header: Sequencing
-        orderOnDetailsPage: 2360
-      - name: qualityControlDetermination
-        ontology_id: GENEPIO:0100559
-        definition: The determination (result) of a quality control assessment.
-        #guidance: Select a value from the pick list provided. If a desired value is missing, submit a new term request to the PHA4GE QC Tag GitHub issuetracker using the New Term Request form.
-        example: sequence failed quality control
-        displayName: Quality control determination
-        header: Sequencing
-        orderOnDetailsPage: 2380
-      - name: qualityControlIssues
-        ontology_id: GENEPIO:0100560
-        definition: The reason contributing to, or causing, a low quality determination in a quality control assessment.
-        #guidance: Select a value from the pick list provided. If a desired value is missing, submit a new term request to the PHA4GE QC Tag GitHub issuetracker using the New Term Request form.
-        example: low average genome coverage
-        displayName: Quality control issues
-        header: Sequencing
-        orderOnDetailsPage: 2400
-      - name: qualityControlDetails
-        ontology_id: GENEPIO:0100561
-        definition: The details surrounding a low quality determination in a quality control assessment.
-        example: CT value of 39. Low viral load. Low DNA concentration after amplification.
-        displayName: Quality control details
-        header: Sequencing
-        orderOnDetailsPage: 2500
       - name: diagnosticMeasurementMethod
         displayName: Diagnostic measurement - method
         header: Diagnostics


### PR DESCRIPTION
When going over the metadata fields I found a number of fields that we do not use and we should probably not allow users to input as this will confuse other users. 

These are 
- `referenceGenomeAccession`: We align sequences to a reference and should not allow users to specify this value themselves
-  `qualityControlMethodName`, `qualityControlMethodVersion`, `qualityControlDetermination`, `qualityControlIssues`, `qualityControlDetails`: we perform our own QC on sequences and show these results adding additional QC values from submitters will be confusing and is not needed

We can also condense certain fields to reduce metadata schema bloat: 
- `diagnosticMeasurementValue` and `diagnosticMeasurementUnit` can be joined
- `previousInfectionOrganism` 
 is not required as `previousInfectionDisease` is also an option and should include these details
- `exposureSetting` and `exposureEvent` can be joined