### PR TITLE
Use new RSV datasets, remove no-longer-needed mpox v11

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -64,11 +64,11 @@ lineageSystemDefinitions:
   mpox:
     12: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/lineages.yaml
   rsv-a:
-    11: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/lineages.yaml
-    12: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/lineages.yaml
+    11: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2024-11-27--02-51-00Z/lineages.yaml
+    12: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
   rsv-b:
-    11: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-b/lineages.yaml
-    12: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-b/lineages.yaml
+    11: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-b/2025-03-04--17-31-25Z/lineages.yaml
+    12: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-b/2025-08-25--09-00-35Z/lineages.yaml
   hmpv:
     11: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/hmpv/lineages.yaml
 defaultOrganismConfig: &defaultOrganismConfig

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2501,7 +2501,7 @@ organisms:
         defaultOrder: descending
     preprocessing:
       - <<: *preprocessing
-        replicas: 3
+        replicas: 1
         configFile:
           <<: *preprocessingConfigFile
           nextclade_dataset_name: "nextstrain/rsv/a/EPI_ISL_412866"
@@ -2513,7 +2513,7 @@ organisms:
           genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
       - <<: *preprocessing
         version: 12
-        replicas: 3
+        replicas: 6
         configFile:
           <<: *preprocessingConfigFile
           nextclade_dataset_name: "nextstrain/rsv/a/EPI_ISL_412866"
@@ -2618,7 +2618,7 @@ organisms:
         defaultOrder: descending
     preprocessing:
       - <<: *preprocessing
-        replicas: 3
+        replicas: 1
         configFile:
           <<: *preprocessingConfigFile
           nextclade_dataset_name: "nextstrain/rsv/b/EPI_ISL_1653999"
@@ -2630,7 +2630,7 @@ organisms:
           genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
       - <<: *preprocessing
         version: 12
-        replicas: 3
+        replicas: 6
         configFile:
           <<: *preprocessingConfigFile
           nextclade_dataset_name: "nextstrain/rsv/b/EPI_ISL_1653999"

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -62,12 +62,13 @@ sequenceFlagging:
     issueTemplate: test-sequence-metadata-issue.md
 lineageSystemDefinitions:
   mpox:
-    11: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/lineages.yaml
     12: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/lineages.yaml
   rsv-a:
     11: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/lineages.yaml
+    12: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/lineages.yaml
   rsv-b:
     11: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-b/lineages.yaml
+    12: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-b/lineages.yaml
   hmpv:
     11: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/hmpv/lineages.yaml
 defaultOrganismConfig: &defaultOrganismConfig
@@ -1890,11 +1891,11 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         replicas: 3
-        version: 11
+        version: 12
         configFile:
           <<: *preprocessingConfigFile
           nextclade_dataset_name: nextstrain/mpox/all-clades
-          nextclade_dataset_tag: 2025-04-25--12-24-24Z
+          nextclade_dataset_tag: 2025-09-09--12-13-13Z
           batch_size: 5
           genes: &mpoxGenes
             - OPG001
@@ -2072,15 +2073,15 @@ organisms:
             - OPG208
             - OPG209
             - OPG210
-      - <<: *preprocessing
-        replicas: 3
-        version: 12
-        configFile:
-          <<: *preprocessingConfigFile
-          nextclade_dataset_name: nextstrain/mpox/all-clades
-          nextclade_dataset_tag: 2025-09-09--12-13-13Z
-          batch_size: 5
-          genes: *mpoxGenes
+      # - <<: *preprocessing
+      #   replicas: 3
+      #   version: 12
+      #   configFile:
+      #     <<: *preprocessingConfigFile
+      #     nextclade_dataset_name: nextstrain/mpox/all-clades
+      #     nextclade_dataset_tag: 2025-09-09--12-13-13Z
+      #     batch_size: 5
+      #     genes: *mpoxGenes
     ingest:
       <<: *ingest
       configFile:
@@ -2510,18 +2511,18 @@ organisms:
           accepted_dataset_matches: 
             - rsv-a
           genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
-      # - <<: *preprocessing
-      #   version: 12
-      #   replicas: 3
-      #   configFile:
-      #     <<: *preprocessingConfigFile
-      #     nextclade_dataset_name: "nextstrain/rsv/a/EPI_ISL_412866"
-      #     nextclade_dataset_tag: "2024-11-27--02-51-00Z"
-      #     require_nextclade_sort_match: true
-      #     minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
-      #     accepted_dataset_matches: 
-      #       - rsv-a
-      #     genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
+      - <<: *preprocessing
+        version: 12
+        replicas: 3
+        configFile:
+          <<: *preprocessingConfigFile
+          nextclade_dataset_name: "nextstrain/rsv/a/EPI_ISL_412866"
+          nextclade_dataset_tag: 2025-08-25--09-00-35Z
+          require_nextclade_sort_match: true
+          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
+          accepted_dataset_matches: 
+            - rsv-a
+          genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
     ingest:
       <<: *ingest
       configFile:
@@ -2627,18 +2628,18 @@ organisms:
           accepted_dataset_matches: 
             - rsv-b
           genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
-      # - <<: *preprocessing
-      #   version: 12
-      #   replicas: 3
-      #   configFile:
-      #     <<: *preprocessingConfigFile
-      #     nextclade_dataset_name: "nextstrain/rsv/b/EPI_ISL_1653999"
-      #     nextclade_dataset_tag: "2025-03-04--17-31-25Z"
-      #     require_nextclade_sort_match: true
-      #     minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
-      #     accepted_dataset_matches: 
-      #       - rsv-b
-      #     genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
+      - <<: *preprocessing
+        version: 12
+        replicas: 3
+        configFile:
+          <<: *preprocessingConfigFile
+          nextclade_dataset_name: "nextstrain/rsv/b/EPI_ISL_1653999"
+          nextclade_dataset_tag: 2025-08-25--09-00-35Z
+          require_nextclade_sort_match: true
+          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
+          accepted_dataset_matches: 
+            - rsv-b
+          genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
     ingest:
       <<: *ingest
       configFile:


### PR DESCRIPTION
- Updated RSV lineage hierarchies files with new lineages: https://github.com/pathoplexus/silo-lineage-hierarchy-definitions/pull/3
- Add RSV prepro v12 with new Nextclade dataset tag [2025-08-25--09-00-35Z](https://github.com/nextstrain/nextclade_data/releases/tag/2025-08-25--09-00-35Z)
- Remove mpox prepro v11 as prod has successfully upgraded to v12

Question: Do we need to do anything about the fact that Nextclade dataset changed the M2-2 protein annotation in GFF to start later? My concern is that the SILO reference now no longer matches the translation result from Nextclade. This might be something to validate/warn for in silo-preprocessing (the place where we'd get both the alignment and the references)

<img width="1144" height="805" alt="Google Chrome 2025-09-12 08 38 22" src="https://github.com/user-attachments/assets/54718f7f-cf8f-4c93-beb9-d1c3f204f279" />

https://github.com/nextstrain/nextclade_data/releases/tag/2025-08-25--09-00-35Z

Preview: https://preview-new-rsv-dataset.pathoplexus.org/