### PR TITLE
Bump RSV-B dataset and remove obsolete mpox v11

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2518,6 +2518,8 @@ organisms:
       #   configFile:
       #     <<: *preprocessingConfigFile
       #     nextclade_dataset_name: "nextstrain/rsv/a/EPI_ISL_412866"
+      #     # Can't bump yet due to change in gene M2-2 coordinates and zstd compression
+      #     # See https://github.com/pathoplexus/pathoplexus/pull/648#issuecomment-3284324612
       #     nextclade_dataset_tag: 2024-11-27--02-51-00Z
       #     require_nextclade_sort_match: true
       #     minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"


### PR DESCRIPTION
Like PR #648 but without new RSV-A dataset due to zstd compression etc.

- Remove obsolete mpox v11
- Add RSV-B v12
- Use tagged lineage hierarchies