### PR TITLE
improve revoke cronjob messages

### DIFF
--- a/data-integrity-tests/revoke-suppressed-sequences/revoke_suppressed.py
+++ b/data-integrity-tests/revoke-suppressed-sequences/revoke_suppressed.py
@@ -184,9 +184,6 @@ def main(insdc_accession, organism, username, password):
             to_revoke.append(sequence_id)
         else:
             logger.warning(f"The sequence {sequence_id} is not suppressed or could not be determined.")
-            # raise ValueError(
-            #     f"The sequence {sequence_id} is not suppressed or could not be determined."
-            # )
 
     revoke(organism, username, password, accessions_list=to_revoke)
     approve(organism, username, password)


### PR DESCRIPTION
I give the script a list of accessions that were once ingested but are no longer ingested. then currently it checks each if it is suppressed and throws an error and crashes if any of the accessions are not suppressed. If all are suppressed it revokes them. This way it checks if each is suppressed, revokes the ones that are suppressed and prints a warning if some were not actually suppressed and we can investigate manually what happened there