### PR TITLE
feat(config): improve metrics ordering on details page & bump pipeline version for ebola-zaire, rsv-a, rsv-b, hmpv & measles to add stop codons

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1434,6 +1434,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         header: "Alignment and QC metrics"
         orderOnDetailsPage: 2830
         noInput: true
+        perSegment: true
         preprocessing:
           inputs: {input: nextclade.qc.stopCodons.totalStopCodons}
       - name: stopCodons
@@ -1441,6 +1442,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         header: "Alignment and QC metrics"
         orderOnDetailsPage: 2840
         noInput: true
+        perSegment: true
         preprocessing:
           inputs: {input: nextclade.qc.stopCodons.stopCodons}
     website: &website


### PR DESCRIPTION
As pointed out by @corneliusroemer not all organisms previously had the stop codon field and we now will need to reprocess those that did not before: https://github.com/pathoplexus/pathoplexus/pull/661#issuecomment-3322916460

Most organisms will be bumped to version 12, except for rsv-a and rsv-b which will now be bumped to version 13.

https://preview-update-prepro-pipeline.pathoplexus.org/

<img width="596" height="612" alt="image" src="https://github.com/user-attachments/assets/dde0bf88-1720-46c3-9c09-cff1c623237b" />
