### PR TITLE
test(integrity): replace sponge and use TSV-ESCAPED dataformat

### DIFF
--- a/data-integrity-tests/regression-testing/Snakefile
+++ b/data-integrity-tests/regression-testing/Snakefile
@@ -55,7 +55,7 @@ def url(w):
     )
     match filetype:
         case "metadata":
-            return base + "details" + rest + "&dataFormat=TSV"
+            return base + "details" + rest + "&dataFormat=TSV-ESCAPED"
         case "sequence":
             return base + "unalignedNucleotideSequences" + rest
         case _:


### PR DESCRIPTION
- **fix(test): replace sponge with temp files, as sponge struggles with >2GB on macOS**
- **use tsv-escaped for metadata download**

Also speeds up a lot by writing intermediary files as zstd compressed to disk.
