### PR TITLE
feat: add MeaNS2 ID field to measles

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2766,6 +2766,12 @@ organisms:
             inputs: {input: nextclade.clade}
           order: 5
           orderOnDetailsPage: 760
+        - name: means2Id
+          displayName: "MeaNS2 ID"
+          header: "Sample details"
+          orderOnDetailsPage: 630
+          definition: "MeaNS2 ID"
+          guidance: "Add the MeaNS2 ID if sequence has also been uploaded to MeaNS2"
       website: 
         <<: *website
         tableColumns:


### PR DESCRIPTION
Resolves #691

This adds a MeaNS2 ID field to measles. As discussed, it's a simple string field without any validation.

Preview: https://preview-means2id.pathoplexus.org/

---

I tested the upload manually and it works:

<img width="435" height="165" alt="image" src="https://github.com/user-attachments/assets/333ddedf-000b-4031-a183-bd93ddc3ad04" />
