### PR TITLE
make 5.Persistence font size same as other headings

### DIFF
--- a/monorepo/website/src/pages/about/governance/data-submission.mdx
+++ b/monorepo/website/src/pages/about/governance/data-submission.mdx
@@ -76,7 +76,7 @@ Metadata:
 
 You can see a full list of the data fields we support [here](/docs/concepts/metadataformat).
 
-## 5. Persistence
+# 5. Persistence
 
 Pathoplexus is not designed to be the sole final resting place for sequence data. Instead, it is designed to add value to existing public data and to facilitate sharing of additional data. In particular, it provides easy access to datasets via API, allows easy upload of data to public repositories, and provides a temporary, protected holding-place for data allowing data generators time to analyze and publish their work. Thus, Users and Submitters should understand that all submitted sequences will be submitted onward to INSDC databases eventually (after a maximum of one year). This allows data to persist and be reused by others in a sustainable, long-term framework.
 


### PR DESCRIPTION
For some reason '5. Persistence' is a smaller font size (heading size) than other headings in [Data Submission doc](https://pathoplexus.org/about/governance/data-submission#5-persistence).
<img width="476" height="556" alt="image" src="https://github.com/user-attachments/assets/8b303e9e-b456-4cfc-b448-067931e5999a" />


Fixed by removing one hash