### PR TITLE
DO NOT MERGE: test compression dict migration

### DIFF
--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 414406bab1391d9b498239f28716d35a90dde73f
+loculusVersion: b39684982c898226aae9c65649cff8a2a6e80f78
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
- [x]  Submit 2 sequences to CCHF (revise: PP_004D78F.1 and revoke: PP_004D76K.1), submit 2 ebola sequences (revise: PP_004D5C9.1, revoke: PP_004D5D7.1)
- [x]  set loculus to migration: https://github.com/loculus-project/loculus/pull/5383 submit a sequence during migration and approve: PP_004DD4H.1, check that migration is successful (also of not submitted but not approved sequences)
`2025-11-18 14:07:40,758 INFO [scheduling-1] [] [] - org.loculus.backend.service.submission.SequenceCompressionMigrationService: Backfill: DONE (originalData=184541, processedData=50)` -> not all sequences were migrated, this might be linked to the fact that the DB migration was temporarily stuck and the service might have started running before the columns were added
- [x]  After migration: submit new sequences PP_004DDGT (that was previously submitted not approved) and CCHF and try to revise an original sequence (that was migrated): PP_004D78F.3 and PP_000REE9.4
- [x] check state of migration dictionary: all rows have migration time and spot check shows dictID has been added correctly
- [x]  Delete unneeded migration code and confirm still healthy: set to https://github.com/loculus-project/loculus/pull/5461

https://preview-migration-test.pathoplexus.org/