### PR TITLE
Fix formatting in newsItems.ts excerpt

### DIFF
--- a/monorepo/website/src/data/newsItems.ts
+++ b/monorepo/website/src/data/newsItems.ts
@@ -11,7 +11,7 @@ export const newsItems: NewsItem[] = [
         title: 'Expanding Pathoplexus: Marburg virus added',
         date: '28 November 2025',
         excerpt:
-            "Today, Pathoplexus launches an additional viral pathogen: Marburgvirus (formally the species _Orthomarburgvirus marburgense_), a member of the Filoviridae family, which includes Ebola viruses. The Marburgvirus species contains both Marburg virus (MARV), and its close relative Ravn virus (RAVV)…"
+            "Today, Pathoplexus launches an additional viral pathogen: Marburgvirus (formally the species Orthomarburgvirus marburgense), a member of the Filoviridae family, which includes Ebola viruses. The Marburgvirus species contains both Marburg virus (MARV), and its close relative Ravn virus (RAVV)…"
     },
     {
         slug: '2025-11-18-november-update',


### PR DESCRIPTION
Markdown doesn't work in excerpts

<img width="334" height="159" alt="Google Chrome 2025-12-02 12 08 13" src="https://github.com/user-attachments/assets/6102fc34-27a2-4d99-a9bd-d13a28a54edd" />
