### PR TITLE
feat(config): update mpox config

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -63,6 +63,7 @@ sequenceFlagging:
 lineageSystemDefinitions:
   mpox:
     12: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2025-09-09--12-13-13Z/lineages.yaml
+    13: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2025-12-10--14-52-38Z/lineages.yaml
   rsv-a:
     14: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
   rsv-b:
@@ -1902,7 +1903,7 @@ organisms:
         defaultOrder: descending
     preprocessing:
       - <<: *preprocessing
-        replicas: 3
+        replicas: 1
         version:
           - 12
         configFile:
@@ -2088,17 +2089,17 @@ organisms:
                 - OPG208
                 - OPG209
                 - OPG210
-      # - <<: *preprocessing
-      #   replicas: 3
-      #   version: 12
-      #   configFile:
-      #     <<: *preprocessingConfigFile
-            # batch_size: 5
-            # nextclade_sequence_and_datasets: 
-            #   - name: main
-            #     nextclade_dataset_name: nextstrain/mpox/all-clades
-            #     nextclade_dataset_tag: 2025-09-09--12-13-13Z
-            #     genes: *mpoxGenes
+      - <<: *preprocessing
+        replicas: 5
+        version: 13
+        configFile:
+          <<: *preprocessingConfigFile
+          batch_size: 5
+          nextclade_sequence_and_datasets: 
+            - name: main
+              nextclade_dataset_name: nextstrain/mpox/all-clades
+              nextclade_dataset_tag: 2025-12-10--14-52-38Z
+              genes: *mpoxGenes
     ingest:
       <<: *ingest
       configFile:


### PR DESCRIPTION
Update nextclade dataset to https://github.com/nextstrain/nextclade_data/releases/tag/2025-12-10--14-52-38Z

## Lineage, clade and outbreak changes
https://github.com/pathoplexus/silo-lineage-hierarchy-definitions/blob/main/definitions/mpox/2025-09-09--12-13-13Z/lineages.yaml
It looks like we only have a lineage definition file for the lineages not the clades or the outbreaks. So this means we actually do not have to update the lineage definition file. 

For consistency however I will create a copy of the existing file and label it as the date of this nextclade dataset release: https://github.com/pathoplexus/silo-lineage-hierarchy-definitions/pull/9 - this should be merged first