### PR TITLE
Reprocess mpox for new clade/outbreaks

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -63,6 +63,7 @@ sequenceFlagging:
 lineageSystemDefinitions:
   mpox:
     12: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2025-09-09--12-13-13Z/lineages.yaml
+    13: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2025-09-09--12-13-13Z/lineages.yaml
   rsv-a:
     14: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
   rsv-b:
@@ -1901,15 +1902,17 @@ organisms:
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
     preprocessing:
-      - <<: *preprocessing
-        replicas: 3
+      - &mpoxPreprocessing
+        <<: *preprocessing
+        replicas: 1
         version:
           - 12
         configFile:
           <<: *preprocessingConfigFile
           batch_size: 5
           nextclade_sequence_and_datasets: 
-            - name: main
+            - &mpoxDataset
+              name: main
               nextclade_dataset_name: nextstrain/mpox/all-clades
               nextclade_dataset_tag: "2025-09-09--12-13-13Z"
               genes: &mpoxGenes
@@ -2088,17 +2091,16 @@ organisms:
                 - OPG208
                 - OPG209
                 - OPG210
-      # - <<: *preprocessing
-      #   replicas: 3
-      #   version: 12
-      #   configFile:
-      #     <<: *preprocessingConfigFile
-            # batch_size: 5
-            # nextclade_sequence_and_datasets: 
-            #   - name: main
-            #     nextclade_dataset_name: nextstrain/mpox/all-clades
-            #     nextclade_dataset_tag: 2025-09-09--12-13-13Z
-            #     genes: *mpoxGenes
+      - <<: *mpoxPreprocessing
+        replicas: 3
+        version:
+          - 13
+        configFile:
+          <<: *preprocessingConfigFile
+          batch_size: 10
+          nextclade_sequence_and_datasets:
+            - <<: *mpoxDataset
+              nextclade_dataset_tag: "2025-12-10--14-52-38Z"
     ingest:
       <<: *ingest
       configFile:


### PR DESCRIPTION
https://preview-new-mpox-dataset.ppx.bio

Update nextclade dataset to https://github.com/nextstrain/nextclade_data/releases/tag/2025-12-10--14-52-38Z

## Lineage, clade and outbreak changes
https://github.com/pathoplexus/silo-lineage-hierarchy-definitions/blob/main/definitions/mpox/2025-09-09--12-13-13Z/lineages.yaml
It looks like we only have a lineage definition file for the lineages not the clades or the outbreaks. So this means we actually do not have to update the lineage definition file. 