### PR TITLE
Bump mpox dataset to fix clade assignments

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -68,8 +68,8 @@ pipelineVersionUpgradeCheckIntervalSeconds: 300
 zstdCompressionLevel: 20
 lineageSystemDefinitions:
   mpox:
-    12: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2025-09-09--12-13-13Z/lineages.yaml
     13: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2025-09-09--12-13-13Z/lineages.yaml
+    15: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2025-09-09--12-13-13Z/lineages.yaml
   rsv-a:
     14: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
   rsv-b:
@@ -77,7 +77,6 @@ lineageSystemDefinitions:
   hmpv:
     12: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/hmpv/2025-09-09--12-13-13Z/lineages.yaml
   cchfS:
-    12: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/cchf/S/2025-09-24--07-29-03Z/lineages.yaml
     13: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/cchf/S/2025-09-24--07-29-03Z/lineages.yaml
   marburg:
     12: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/marburg/2025-09-09--12-13-13Z/lineages.yaml
@@ -1537,7 +1536,7 @@ organisms:
         taxon_id: 3052462
     preprocessing:
       - <<: *preprocessing
-        replicas: 2
+        replicas: 1
         version:
           - 12
         configFile:
@@ -1779,7 +1778,6 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 12
           - 13
         configFile:
           <<: *preprocessingConfigFile
@@ -1912,7 +1910,7 @@ organisms:
         <<: *preprocessing
         replicas: 1
         version:
-          - 12
+          - 13
         configFile:
           <<: *preprocessingConfigFile
           batch_size: 5
@@ -1920,7 +1918,7 @@ organisms:
             - &mpoxDataset
               name: main
               nextclade_dataset_name: nextstrain/mpox/all-clades
-              nextclade_dataset_tag: "2025-09-09--12-13-13Z"
+              nextclade_dataset_tag: 2025-12-12--16-44-41Z
               genes: &mpoxGenes
                 - OPG001
                 - OPG002
@@ -2100,13 +2098,13 @@ organisms:
       - <<: *mpoxPreprocessing
         replicas: 3
         version:
-          - 13
+          - 15
         configFile:
           <<: *preprocessingConfigFile
           batch_size: 10
           nextclade_sequence_and_datasets:
             - <<: *mpoxDataset
-              nextclade_dataset_tag: "2025-12-12--16-44-41Z"
+              nextclade_dataset_tag: 2025-12-16--20-07-31Z
     ingest:
       <<: *ingest
       configFile:


### PR DESCRIPTION
Use new mpox dataset. Use version 15 to speed up joins etc - each version should only be used by one organism.