### PR TITLE
fix(config): remove invalid spec.arg field

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -186,7 +186,6 @@ defaultOrganismConfig: &defaultOrganismConfig
             sampleCollectionDate: sampleCollectionDate
           args:
             order: [geoLocCountry, accession_version, sampleCollectionDate]
-            orderOnDetailsPage: 180
             type: [string, string, string]
         noInput: true
       - name: ncbiReleaseDate


### PR DESCRIPTION
Pydantic has flagged that we had an invalid field in the config (this was unused previously and thus did not cause errors but should be removed)

```
Traceback (most recent call last):
  File "/opt/conda/bin/prepro", line 10, in <module>
    sys.exit(cli_entry())
             ~~~~~~~~~^^
  File "/opt/conda/lib/python3.14/site-packages/loculus_preprocessing/__main__.py", line 12, in cli_entry
    config = get_config()
  File "/opt/conda/lib/python3.14/site-packages/loculus_preprocessing/config.py", line 177, in get_config
    config = Config(**yaml_config)
  File "/opt/conda/lib/python3.14/site-packages/pydantic/main.py", line 250, in __init__
    validated_self = self.__pydantic_validator__.validate_python(data, self_instance=self)
pydantic_core._pydantic_core.ValidationError: 3 validation errors for Config
processing_spec.displayName.args.orderOnDetailsPage.list[str]
  Input should be a valid list [type=list_type, input_value=180, input_type=int]
    For further information visit https://errors.pydantic.dev/2.12/v/list_type
processing_spec.displayName.args.orderOnDetailsPage.str
  Input should be a valid string [type=string_type, input_value=180, input_type=int]
    For further information visit https://errors.pydantic.dev/2.12/v/string_type
processing_spec.displayName.args.orderOnDetailsPage.bool
  Input should be a valid boolean, unable to interpret input [type=bool_parsing, input_value=180, input_type=int]
    For further information visit https://errors.pydantic.dev/2.12/v/bool_parsing
```