### PR TITLE
Change measles ingest taxon_id from 11234 to 3052345

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2867,7 +2867,7 @@ organisms:
       <<: *ingest
       configFile:
         <<: *defaultIngestConfigFile
-        taxon_id: 11234
+        taxon_id: 3052345
     enaDeposition:
       singleReference:
         configFile:


### PR DESCRIPTION
Updated taxon_id for ingest configuration.

resolves #802

https://preview-measles-ingest.pathoplexus.org/measles/search?
