### PR TITLE
feat: add grouping_override URL to CCHF values.yaml

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1814,6 +1814,7 @@ organisms:
         segment_identification:
           method: "align"
           nextclade_dataset_name: community/pathoplexus/cchfv
+        grouping_override: "https://pathoplexus.github.io/curation_data/grouping_override/cchf/curated_group_13-02-2026.json"
     enaDeposition:
       singleReference:
         configFile:


### PR DESCRIPTION
Due to the curation of CCHF sequences ingested from the INSDC (see details in https://github.com/pathoplexus/curation_reports/issues/12)   ingest would like to regroup the curated seqences, I believe it is easiest to just set the curated sequence in the override so ingest nolonger attempts to update/ungroup the sequences: https://loculus.slack.com/archives/C07NDUW0171/p1770997463747449

This should only be merged on PPX production when the curation has been approved - curation is now approved!!

preview: https://preview-anna-parker-patch-8.pathoplexus.org/