### PR TITLE
testing: Simplify organism cards layout and remove center alignment

### DIFF
--- a/monorepo/website/src/components/IndexPage/OrganismCard.astro
+++ b/monorepo/website/src/components/IndexPage/OrganismCard.astro
@@ -1,0 +1,50 @@
+---
+import type { OrganismStatistics } from './getOrganismStatistics';
+import { routes } from '../../routes/routes';
+import { formatNumberWithDefaultLocale } from '../../utils/formatNumber';
+
+interface Props {
+    key: string;
+    image: string | undefined;
+    displayName: string;
+    organismStatistics: OrganismStatistics;
+    numberDaysAgoStatistics: number;
+}
+
+const { key, image, displayName, organismStatistics, numberDaysAgoStatistics } = Astro.props;
+---
+
+<a
+    href={routes.organismStartPage(key)}
+    class='shadow-[0_3px_10px_rgb(0,0,0,0.1)]
+    block rounded-lg
+    hover:brightness-115
+    hover:shadow-[0_3px_10px_rgb(0,0,0,0.2)]
+    hover:no-underline
+    transition-all duration-200 ease-in-out'
+>
+    {image !== undefined && <img src={image} class='h-40 w-full object-cover rounded-t-[8px]' alt={displayName} />}
+    <div class='my-4 mx-4 h-28 flex flex-col justify-between text-slate-900'>
+        <h3 class='font-semibold mb-2'>{displayName}</h3>
+        <p class='text-sm leading-7'>
+            <span class='font-bold'>
+                {formatNumberWithDefaultLocale(organismStatistics.totalSequences)}
+            </span>
+            sequences
+            <br />
+            <span class='text-slate-400 text-sm'>
+                <span class='text-slate-500'>
+                    +{formatNumberWithDefaultLocale(organismStatistics.recentSequences)}
+                </span>
+                in last {numberDaysAgoStatistics} days
+            </span>
+            <span class='hidden'
+                >{
+                    organismStatistics.lastUpdatedAt && (
+                        <>Last updated {organismStatistics.lastUpdatedAt.toRelative()}</>
+                    )
+                }</span
+            >
+        </p>
+    </div>
+</a>

--- a/monorepo/website/src/pages/index.astro
+++ b/monorepo/website/src/pages/index.astro
@@ -118,7 +118,7 @@ const hasAggregateStats = aggregateSubmissionStats.total > 0;
 
         <section>
             <h2 class='text-2xl font-semibold text-slate-900'>Explore the data</h2>
-            <div class='mt-8 flex flex-wrap gap-x-5 gap-y-4'>
+            <div class='mt-8 grid grid-cols-[repeat(auto-fill,minmax(14rem,1fr))] gap-x-5 gap-y-4'>
                 {
                     configuredOrganisms.map(({ key, displayName, image }) => (
                         <OrganismCard


### PR DESCRIPTION
## Summary
Refactored the "Explore the data" section layout to simplify the card container structure and remove unnecessary centering constraints.

## Key Changes
- Removed `text-center` class from the section heading
- Simplified the card container by removing the nested wrapper div with `justify-center` and conditional `max-w-4xl` class
- Moved flex properties (`flex-wrap`, `gap-x-5`, `gap-y-4`) directly to the main container
- Removed the conditional max-width constraint that was applied when exactly 5 organisms were configured

## Implementation Details
The layout now uses a simpler, single-level flex container for the organism cards instead of the previous nested structure. This change maintains the card spacing and wrapping behavior while reducing DOM complexity. The cards will now flow naturally without the center alignment constraint, allowing them to align to the start of their container.

https://claude.ai/code/session_017PchzDJdAHEXpMacSnGG5H