### PR TITLE
feat: update cchf grouping overrides

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1814,7 +1814,7 @@ organisms:
         segment_identification:
           method: "align"
           nextclade_dataset_name: community/pathoplexus/cchfv
-        grouping_override: "https://pathoplexus.github.io/curation_data/grouping_override/cchf/curated_group_13-02-2026.json"
+        grouping_override: "https://pathoplexus.github.io/curation_data/grouping_override/cchf/curated_group_02-03-2026.json"
     enaDeposition:
       singleReference:
         configFile:


### PR DESCRIPTION
Update the grouping overrides to include the curation discussed in https://github.com/pathoplexus/curation_reports/issues/4

Curated group added here with INSDC accessions: https://github.com/pathoplexus/curation_data/blob/main/grouping_override/cchf/curated_group_02-03-2026.json%E2%80%8E#L6

Once this is rolled out on staging the sequences:
https://pathoplexus.org/seq/PP_000SMLM.1
https://pathoplexus.org/seq/PP_000SMNH.1
https://pathoplexus.org/seq/PP_000SMMK.1

will all need to be revoked with a comment linking 

preview: https://preview-cchf-curation.pathoplexus.org/ - new group here: https://preview-cchf-curation.pathoplexus.org/seq/PPD_001XFCZ.1