### PR TITLE
fix(dengue, yellow-fever) Display names for `displayName` field

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1748,6 +1748,7 @@ organisms:
           desired: true
         # custom displayName construction for Dengue
         - name: displayName
+          displayName: Display name
           noInput: true
           preprocessing:
             function: build_display_name
@@ -3373,6 +3374,7 @@ organisms:
           desired: true
         # custom displayName construction for YFV
         - name: displayName
+          displayName: Display name
           noInput: true
           preprocessing:
             function: build_display_name


### PR DESCRIPTION
This PR adds a small fix to add display names for the `displayName` field on dengue and yellow-fever.