### PR TITLE
Added GitHub issues url and issues email to `values.yaml`

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -7,6 +7,8 @@ runDevelopmentMainDatabase: true
 bannerMessage: This is a preview instance. Do not rely on this data for real analyses.
 gitHubEditLink: https://github.com/pathoplexus/pathoplexus/edit/main/monorepo/website/
 gitHubMainUrl: https://github.com/pathoplexus/pathoplexus
+gitHubIssuesUrl: https://github.com/pathoplexus/pathoplexus/issues
+issuesEmail: bug@pathoplexus.org
 runDevelopmentKeycloakDatabase: true
 runDevelopmentS3: false
 s3:


### PR DESCRIPTION
This PR adds a `gitHubIssuesUrl` and `issuesEmail` for Pathoplexus, as these are now configured within Loculus as of version [a04093a](https://github.com/loculus-project/loculus/commit/a04093a490575b1e648931c5208ae767eca056d3).

Requires at least Loculus version [a04093a](https://github.com/loculus-project/loculus/commit/a04093a490575b1e648931c5208ae767eca056d3) before merging.

