### PR TITLE
Add how-to-cite page

### DIFF
--- a/monorepo/website/src/pages/about/citation.mdx
+++ b/monorepo/website/src/pages/about/citation.mdx
@@ -34,7 +34,7 @@ You must first determine whether your Restricted-Use Data is part of the **Focal
 ### If Restricted-Use Data is in your Focal Set, you must do **all three** of the following:
 
 1. **Include authorship** from the Submitting Group — or obtain and include a written Authorship Waiver as a supplemental document.
-2. Create a SeqSet, generate a DOI, and cite the DOI **as a reference** in your manuscript. ([How to create a SeqSet](https://claude.ai/docs/how-to/generate-seqset))
+2. Create a SeqSet, generate a DOI, and cite the DOI **as a reference** in your manuscript. ([How to create a SeqSet](https://pathoplexus.org/docs/how-to/generate-seqset))
 3. **Add to your Acknowledgements**: _"We confirm that we have adhered to the Data Use Terms of Pathoplexus."_
 
 ### If Restricted-Use Data is in your Background Set, you must:

--- a/monorepo/website/src/pages/about/citation.mdx
+++ b/monorepo/website/src/pages/about/citation.mdx
@@ -24,7 +24,7 @@ Restricted-Use Data has binding requirements. Using it means you've agreed to th
 
 ## For unpublished work (reports, blog posts, social media, web tools)
 
-- Provide a list of accession numbers used, or create a [SeqSet](https://claude.ai/docs/how-to/generate-seqset) (recommended if using more than 5 sequences).
+- Provide a list of accession numbers used, or create a [SeqSet](https://pathoplexus.org/docs/how-to/generate-seqset) (recommended if using more than 5 sequences).
 - Link back to Pathoplexus so that submitters can be identified and credited.
 
 ## For publications and preprints

--- a/monorepo/website/src/pages/about/citation.mdx
+++ b/monorepo/website/src/pages/about/citation.mdx
@@ -10,7 +10,7 @@ Not sure which applies to you? Each sequence on Pathoplexus displays its data us
 
 # Open Data
 
-Open Data can be used freely. There are no mandatory citation requirements, but we strongly encourage good scientific practice:
+Open Data can be used freely. While it is not subject to defined terms of use, we strongly encourage good scientific practice:
 
 - Always list the accession numbers for sequences used in your work.
 - Create a SeqSet and generate a DOI — this is the best way to permanently and precisely cite the data you used. ([How to create a SeqSet](https://pathoplexus.org/docs/how-to/generate-seqset))

--- a/monorepo/website/src/pages/about/citation.mdx
+++ b/monorepo/website/src/pages/about/citation.mdx
@@ -29,7 +29,7 @@ Restricted-Use Data has binding requirements. Using it means you've agreed to th
 
 ## For publications and preprints
 
-You must first determine whether your Restricted-Use Data is part of the **Focal data** or the **Background data** of your analysis. These are defined in the [Data Use Terms (section 4.2.3)](https://claude.ai/about/terms-of-use/data-use-terms#423-deciding-if-restricted-use-data-is-part-of-a-focal-or-background-set) — please read carefully, and when in doubt, treat data as Focal.
+You must first determine whether your Restricted-Use Data is part of the **Focal data** or the **Background data** of your analysis. These are defined in the [Data Use Terms (section 4.2.3)](https://pathoplexus.org/about/terms-of-use/data-use-terms#423-deciding-if-restricted-use-data-is-part-of-a-focal-or-background-set) — please read carefully, and when in doubt, treat data as Focal.
 
 ### If Restricted-Use Data is in your Focal Set, you must do **all three** of the following:
 

--- a/monorepo/website/src/pages/about/citation.mdx
+++ b/monorepo/website/src/pages/about/citation.mdx
@@ -63,7 +63,7 @@ A [SeqSet](https://pathoplexus.org/docs/how-to/generate-seqset) is sufficient â€
 
 # How to Create a SeqSet
 
-Full instructions are in our documentation: [Generating & using SeqSets](https://claude.ai/docs/how-to/generate-seqset)
+Full instructions are in our documentation: [Generating & using SeqSets](https://pathoplexus.org/docs/how-to/generate-seqset)
 
 **Key point:** For publications and preprints, the DOI must be cited in your **References section** (as you would cite a paper), not just mentioned in the text. This ensures it is indexed by CrossRef and linked to your manuscript.
 

--- a/monorepo/website/src/pages/about/citation.mdx
+++ b/monorepo/website/src/pages/about/citation.mdx
@@ -13,7 +13,7 @@ Not sure which applies to you? Each sequence on Pathoplexus displays its data us
 Open Data can be used freely. There are no mandatory citation requirements, but we strongly encourage good scientific practice:
 
 - Always list the accession numbers for sequences used in your work.
-- Create a SeqSet and generate a DOI — this is the best way to permanently and precisely cite the data you used. ([How to create a SeqSet](https://claude.ai/docs/how-to/generate-seqset))
+- Create a SeqSet and generate a DOI — this is the best way to permanently and precisely cite the data you used. ([How to create a SeqSet](https://pathoplexus.org/docs/how-to/generate-seqset))
 - Collaborate with data generators, especially when using extensive data from a specific region or country.
 
 Data sharing depends on trust. Even for Open Data, please use it ethically and credit those who generated it.

--- a/monorepo/website/src/pages/about/citation.mdx
+++ b/monorepo/website/src/pages/about/citation.mdx
@@ -68,4 +68,4 @@ Full instructions are in our documentation: [Generating & using SeqSets](https:/
 **Key point:** For publications and preprints, the DOI must be cited in your **References section** (as you would cite a paper), not just mentioned in the text. This ensures it is indexed by CrossRef and linked to your manuscript.
 
 
-_Questions? Contact us at [help@pathoplexus.org](mailto:help@pathoplexus.org) or consult the full [Data Use Terms](https://claude.ai/about/terms-of-use/data-use-terms)._
+_Questions? Contact us at [help@pathoplexus.org](mailto:help@pathoplexus.org) or consult the full [Data Use Terms](https://pathoplexus.org/about/terms-of-use/data-use-terms)._

--- a/monorepo/website/src/pages/about/citation.mdx
+++ b/monorepo/website/src/pages/about/citation.mdx
@@ -20,7 +20,7 @@ Data sharing depends on trust. Even for Open Data, please use it ethically and c
 
 # Restricted-Use Data
 
-Restricted-Use Data has binding requirements. Using it means you've agreed to the [Data Use Terms](https://claude.ai/about/terms-of-use/data-use-terms).
+Restricted-Use Data has binding requirements. Using it means you've agreed to the [Data Use Terms](https://pathoplexus.org/about/terms-of-use/data-use-terms).
 
 ## For unpublished work (reports, blog posts, social media, web tools)
 

--- a/monorepo/website/src/pages/about/citation.mdx
+++ b/monorepo/website/src/pages/about/citation.mdx
@@ -39,7 +39,7 @@ You must first determine whether your Restricted-Use Data is part of the **Focal
 
 ### If Restricted-Use Data is in your Background Set, you must:
 
-- [Create a SeqSet](https://claude.ai/docs/how-to/generate-seqset), generate a DOI, and cite it **as a reference** in your manuscript.
+- [Create a SeqSet](https://pathoplexus.org/docs/how-to/generate-seqset), generate a DOI, and cite it **as a reference** in your manuscript.
 
 # Using All Data (e.g. global analyses or real-time dashboards)
 

--- a/monorepo/website/src/pages/about/citation.mdx
+++ b/monorepo/website/src/pages/about/citation.mdx
@@ -49,7 +49,7 @@ If you're using the entire Pathoplexus dataset for a broad global analysis (e.g.
 Create a SeqSet, generate a DOI, and cite it as a reference.
 
 **For a website or real-time application:**
-A [SeqSet](https://claude.ai/docs/how-to/generate-seqset) is sufficient — you don't need a DOI, since the data on a live site will change over time. Update your SeqSet regularly to reflect the data being used.
+A [SeqSet](https://pathoplexus.org/docs/how-to/generate-seqset) is sufficient — you don't need a DOI, since the data on a live site will change over time. Update your SeqSet regularly to reflect the data being used.
 
 # Quick reference
 

--- a/monorepo/website/src/pages/about/citation.mdx
+++ b/monorepo/website/src/pages/about/citation.mdx
@@ -1,0 +1,71 @@
+---
+layout: ../../layouts/AboutLayout.astro
+title: "Citing Data from Pathoplexus"
+order: 8
+---
+
+Thank you for using Pathoplexus data! Proper citation protects the hard work of data generators and helps sustain a culture of open, rapid sharing. The requirements depend on whether you're using **Open Data**, **Restricted-Use Data**, or **all available data** for a virus.
+
+Not sure which applies to you? Each sequence on Pathoplexus displays its data use status clearly.
+
+# Open Data
+
+Open Data can be used freely. There are no mandatory citation requirements, but we strongly encourage good scientific practice:
+
+- Always list the accession numbers for sequences used in your work.
+- Create a SeqSet and generate a DOI — this is the best way to permanently and precisely cite the data you used. ([How to create a SeqSet](https://claude.ai/docs/how-to/generate-seqset))
+- Collaborate with data generators, especially when using extensive data from a specific region or country.
+
+Data sharing depends on trust. Even for Open Data, please use it ethically and credit those who generated it.
+
+# Restricted-Use Data
+
+Restricted-Use Data has binding requirements. Using it means you've agreed to the [Data Use Terms](https://claude.ai/about/terms-of-use/data-use-terms).
+
+## For unpublished work (reports, blog posts, social media, web tools)
+
+- Provide a list of accession numbers used, or create a [SeqSet](https://claude.ai/docs/how-to/generate-seqset) (recommended if using more than 5 sequences).
+- Link back to Pathoplexus so that submitters can be identified and credited.
+
+## For publications and preprints
+
+You must first determine whether your Restricted-Use Data is part of the **Focal data** or the **Background data** of your analysis. These are defined in the [Data Use Terms (section 4.2.3)](https://claude.ai/about/terms-of-use/data-use-terms#423-deciding-if-restricted-use-data-is-part-of-a-focal-or-background-set) — please read carefully, and when in doubt, treat data as Focal.
+
+### If Restricted-Use Data is in your Focal Set, you must do **all three** of the following:
+
+1. **Include authorship** from the Submitting Group — or obtain and include a written Authorship Waiver as a supplemental document.
+2. Create a SeqSet, generate a DOI, and cite the DOI **as a reference** in your manuscript. ([How to create a SeqSet](https://claude.ai/docs/how-to/generate-seqset))
+3. **Add to your Acknowledgements**: _"We confirm that we have adhered to the Data Use Terms of Pathoplexus."_
+
+### If Restricted-Use Data is in your Background Set, you must:
+
+- [Create a SeqSet](https://claude.ai/docs/how-to/generate-seqset), generate a DOI, and cite it **as a reference** in your manuscript.
+
+# Using All Data (e.g. global analyses or real-time dashboards)
+
+If you're using the entire Pathoplexus dataset for a broad global analysis (e.g., tracking global mutation frequencies with no regional focus), the full dataset may be treated as a Background Set. (See the [Data Use Terms, section 4.3](https://pathoplexus.org/about/terms-of-use/data-use-terms#43-using-all-data) for more details.)
+
+**For a publication or preprint:**
+Create a SeqSet, generate a DOI, and cite it as a reference.
+
+**For a website or real-time application:**
+A [SeqSet](https://claude.ai/docs/how-to/generate-seqset) is sufficient — you don't need a DOI, since the data on a live site will change over time. Update your SeqSet regularly to reflect the data being used.
+
+# Quick reference
+
+| Situation | SeqSet | DOI | Authorship |
+|---|---|---|---|
+| Open Data (any use) | Encouraged | Encouraged | Consider collaborating |
+| Restricted-Use, Background Set, publication | Required | Required | Not required |
+| Restricted-Use, Focal Set, publication | Required | Required | Required (or waiver) |
+| All Data, publication | Required | Required | Not required |
+| All Data, live website | Required | Not required | N/A |
+
+# How to Create a SeqSet
+
+Full instructions are in our documentation: [Generating & using SeqSets](https://claude.ai/docs/how-to/generate-seqset)
+
+**Key point:** For publications and preprints, the DOI must be cited in your **References section** (as you would cite a paper), not just mentioned in the text. This ensures it is indexed by CrossRef and linked to your manuscript.
+
+
+_Questions? Contact us at [help@pathoplexus.org](mailto:help@pathoplexus.org) or consult the full [Data Use Terms](https://claude.ai/about/terms-of-use/data-use-terms)._


### PR DESCRIPTION
As discussed previously, a all-in-one 'how to cite data from Pathoplexus' page - which could be linked from multiple other places too. 

Currently lives in About -> bottom of list - but could be moved there two.

Should the 'quick summary' table go higher up? 

Also - this summarizes all data by saying that SeqSet/DOI is required - this isn't strictly true if all data is open, but I'm not convinced anyone actually checks whether there's restricted data (and if it's an auto-updating app, it could include RU data without someone actively noticing), so if people do both then they are safe no matter what. But let me know what people think.