### PR TITLE
fix(config, website): hide `sampleCollectionDateRangeLower` and `sampleCollectionDateRangeUpper` in column selector

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -145,6 +145,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         example: "2020-03-15"
       - name: sampleCollectionDateRangeLower
         displayName: Collection date (lower bound)
+        hideInSearchResultsTable: true
         hideOnSequenceDetailsPage: true
         type: date
         initiallyVisible: true
@@ -164,6 +165,7 @@ defaultOrganismConfig: &defaultOrganismConfig
         noInput: true
       - name: sampleCollectionDateRangeUpper
         displayName: Collection date (upper bound)
+        hideInSearchResultsTable: true
         hideOnSequenceDetailsPage: true
         type: date
         initiallyVisible: true


### PR DESCRIPTION
Currently on Pathoplexus, in the column selector, the fields 'Collection date (upper bound)' and 'Collection date (lower bound)' are visible when they should not be (and clicking them does not do anything):

<img width="1048" height="346" alt="image" src="https://github.com/user-attachments/assets/1e1e4be1-0e00-49de-ba53-b0360bfae446" />

This is due to missing `hideInSearchResultsTable: true` for those fields in the config, which are added in this PR.