### PR TITLE
Rename grouping_override to grouping_override_url

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2133,7 +2133,7 @@ organisms:
         segment_identification:
           method: "align"
           nextclade_dataset_name: community/pathoplexus/cchfv
-        grouping_override: "https://pathoplexus.github.io/curation_data/grouping_override/cchf/curated_group_02-03-2026.json"
+        grouping_override_url: "https://pathoplexus.github.io/curation_data/grouping_override/cchf/curated_group_02-03-2026.json"
     enaDeposition:
       singleReference:
         configFile:


### PR DESCRIPTION
I forgot that we are actually using this param on PPX during the last update, see https://github.com/loculus-project/loculus/pull/6112 for details

This triggered the notifications in https://loculus.slack.com/archives/C07NDUW0171/p1774386423214259