### PR TITLE
fix: regression tests for dengue (fasta headers included subtype leadi…

### DIFF
--- a/data-integrity-tests/regression-testing/Snakefile
+++ b/data-integrity-tests/regression-testing/Snakefile
@@ -66,7 +66,7 @@ def url(w):
         case "metadata":
             return base + "details" + rest + "&dataFormat=TSV-ESCAPED"
         case "sequence":
-            return base + "unalignedNucleotideSequences" + rest
+            return base + "unalignedNucleotideSequences" + rest + "&fastaHeaderTemplate=%7BaccessionVersion%7D"
         case _:
             raise RuntimeError(f"Unreachable code reached: {filetype=}")
 


### PR DESCRIPTION
…ng sequences diffs to fail)