### PR TITLE
fix: Set maxNumberOfRecommendedEntries: 45000 for all mapoplexus linkouts

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1602,6 +1602,7 @@ organisms:
           maxNumberOfRecommendedEntries: 3000 # ebola is ~18.5kb
           url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences+rich|fasta]}}&dataset-name=nextstrain/orthoebolavirus/ebov"
         - name: "Country map"
+          maxNumberOfRecommendedEntries: 45000
           url: "https://mapoplexus.genomium.org/?url={{[metadata]}}"
       website:
         <<: *website
@@ -1690,6 +1691,7 @@ organisms:
           maxNumberOfRecommendedEntries: 3000 # ebola is ~18.5kb
           url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences+rich|fasta]}}&dataset-name=nextstrain/orthoebolavirus/sudv"
         - name: "Country map"
+          maxNumberOfRecommendedEntries: 45000
           url: "https://mapoplexus.genomium.org/?url={{[metadata]}}"
     preprocessing:
       - <<: *preprocessing
@@ -1772,6 +1774,7 @@ organisms:
           maxNumberOfRecommendedEntries: 2500
           url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences+rich|fasta]}}&dataset-name=community/v-gen-lab/dengue/denv4&dataset-server=https://raw.githubusercontent.com/nextstrain/nextclade_data/master/data_output"
         - name: "Country map"
+          maxNumberOfRecommendedEntries: 45000
           url: "https://mapoplexus.genomium.org/?url={{[metadata]}}"
       # adding custom description of submissionId to show on website
       extraInputFields:
@@ -2056,6 +2059,7 @@ organisms:
           maxNumberOfRecommendedEntries: 2500 # west nile is ~11kb
           url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences+rich|fasta]}}&dataset-name=nextstrain/wnv/all-lineages"
         - name: "Country map"
+          maxNumberOfRecommendedEntries: 45000
           url: "https://mapoplexus.genomium.org/?url={{[metadata]}}"
       metadataAdd:
         - name: lineage
@@ -2171,6 +2175,7 @@ organisms:
           maxNumberOfRecommendedEntries: 10000 # cchf S is ~1.7kB
           url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:S+rich|fasta]}}&dataset-name=community/pathoplexus/cchfv/S"
         - name: "Country map"
+          maxNumberOfRecommendedEntries: 45000
           url: "https://mapoplexus.genomium.org/?url={{[metadata]}}"
       metadataAdd:
         - name: lineage_S
@@ -2300,6 +2305,7 @@ organisms:
           maxNumberOfRecommendedEntries: 200 # Nextclade handles ~80MB of sequences, mpox is ~197kB
           url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences+rich|fasta]}}&dataset-name=nextstrain/mpox/all-clades"
         - name: "Country map"
+          maxNumberOfRecommendedEntries: 45000
           url: "https://mapoplexus.genomium.org/?url={{[metadata]}}"
       metadataAdd:
         - name: clade
@@ -2952,6 +2958,7 @@ organisms:
           maxNumberOfRecommendedEntries: 1300 # RSV is ~15kB
           url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences+rich|fasta]}}&dataset-name=nextstrain/rsv/a/EPI_ISL_412866"
         - name: "Country map"
+          maxNumberOfRecommendedEntries: 45000
           url: "https://mapoplexus.genomium.org/?url={{[metadata]}}"
       metadataAdd:
         - name: lineage
@@ -3084,6 +3091,7 @@ organisms:
           maxNumberOfRecommendedEntries: 1300 # RSV is ~15kB
           url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences+rich|fasta]}}&dataset-name=nextstrain/rsv/b/EPI_ISL_1653999"
         - name: "Country map"
+          maxNumberOfRecommendedEntries: 45000
           url: "https://mapoplexus.genomium.org/?url={{[metadata]}}"
       metadataAdd:
         - name: lineage
@@ -3216,6 +3224,7 @@ organisms:
           maxNumberOfRecommendedEntries: 1500 # HMPV is ~13kB
           url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences+rich|fasta]}}&dataset-name=nextstrain/hmpv/all-clades/NC_039199"
         - name: "Country map"
+          maxNumberOfRecommendedEntries: 45000
           url: "https://mapoplexus.genomium.org/?url={{[metadata]}}"
       metadataAdd:
         - name: lineage
@@ -3317,6 +3326,7 @@ organisms:
       image: "/images/organisms/measles_small.jpg"
       linkOuts:
         - name: "Country map"
+          maxNumberOfRecommendedEntries: 45000
           url: "https://mapoplexus.genomium.org/?url={{[metadata]}}"
         - name: "Nextclade"
           maxNumberOfRecommendedEntries: 1000 # Measles is ~15.9kB
@@ -3423,6 +3433,7 @@ organisms:
       image: "/images/organisms/marburg.jpg"
       linkOuts:
         - name: "Country map"
+          maxNumberOfRecommendedEntries: 45000
           url: "https://mapoplexus.genomium.org/?url={{[metadata]}}"
         - name: "Nextclade"
           maxNumberOfRecommendedEntries: 3000 # marburg is ~19kb
@@ -3525,6 +3536,7 @@ organisms:
           maxNumberOfRecommendedEntries: 2500 # yellow fever is ~11kb
           url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences+rich|fasta]}}&dataset-name=community/pathoplexus/yellow-fever-virus&dataset-server=https://raw.githubusercontent.com/maverbiest/nextclade_data/yellow-fever-virus/data_output"
         - name: "Country map"
+          maxNumberOfRecommendedEntries: 45000
           url: "https://mapoplexus.genomium.org/?url={{[metadata]}}"
       # adding custom description of submissionId to show on website
       extraInputFields:


### PR DESCRIPTION
The linkout to Mapoplexus for does not work when it is called with all ~57k dengue sequences:

<img width="841" height="262" alt="image" src="https://github.com/user-attachments/assets/dd07d1f9-0a17-4cc5-8b12-9b2598b500ac" />

However it does work for:
- All of DENV-1 (23k sequences)
- All of DENV-2 (20K sequences)
- All of DENV-3 (10k sequences)
- All of DENV-4 (5k sequences)
- Two seqs of each serotype
- All of RSV-A (41k sequences)

Potentially, this points to dengue having too many sequences to show in Mapoplexus at once. 

To address this for now, we will set `maxNumberOfRecommendedEntries` to 45000 for all Mapoplexus linkouts so users see a warning before attempting to use Mapoplexus with a large amount of sequences.

### Manual testing
I set up a preview and waited until more than 45000 dengue sequences were available. When I tried to send all of these to Mapoplexus via the linkout, I was met with this warning:

<img width="841" height="507" alt="image" src="https://github.com/user-attachments/assets/ce7ed4ed-52b9-4fcc-a8dd-3384a96ea9ac" />


preview: https://preview-n-seqs-mapoplexus.pathoplexus.org/