### PR TITLE
DO NOT MERGE: Bump pipeline versions for all organisms

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -72,18 +72,25 @@ zstdCompressionLevel: 20
 lineageSystemDefinitions:
   mpox:
     18: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2025-09-09--12-13-13Z/lineages.yaml
+    19: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2025-09-09--12-13-13Z/lineages.yaml
   rsv-a:
     19: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
+    20: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
   rsv-b:
     20: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-b/2025-08-25--09-00-35Z/lineages.yaml
+    21: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-b/2025-08-25--09-00-35Z/lineages.yaml
   hmpv:
     21: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/hmpv/2025-09-09--12-13-13Z/lineages.yaml
+    22: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/hmpv/2025-09-09--12-13-13Z/lineages.yaml
   cchfS:
     21: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/cchf/S/2025-09-24--07-29-03Z/lineages.yaml
+    22: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/cchf/S/2025-09-24--07-29-03Z/lineages.yaml
   marburg:
     22: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/marburg/2025-09-09--12-13-13Z/lineages.yaml
+    23: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/marburg/2025-09-09--12-13-13Z/lineages.yaml
   dengue:
    28: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/dengue/all/2025-09-09--12-13-13Z/lineages.yaml
+   29: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/dengue/all/2025-09-09--12-13-13Z/lineages.yaml
 defaultOrganismConfig: &defaultOrganismConfig
   schema: &schema
     submissionDataTypes: &defaultSubmissionDataTypes
@@ -1629,6 +1636,19 @@ organisms:
                   nextclade_dataset_name: nextstrain/orthoebolavirus/ebov
                   nextclade_dataset_tag: "2025-09-24--07-29-03Z"
                   genes: [NP, VP35, VP40, GP, sGP, ssGP, VP30, VP24, L]
+      - <<: *preprocessing
+        replicas: 1
+        version:
+          - 28
+        configFile:
+          <<: *preprocessingConfigFile
+          segments:
+            - name: main
+              references:
+                - name: "singleReference"
+                  nextclade_dataset_name: nextstrain/orthoebolavirus/ebov
+                  nextclade_dataset_tag: "2025-09-24--07-29-03Z"
+                  genes: [NP, VP35, VP40, GP, sGP, ssGP, VP30, VP24, L]
     enaDeposition:
       singleReference:
         configFile:
@@ -1677,6 +1697,18 @@ organisms:
       - <<: *preprocessing
         version:
           - 24
+        configFile:
+          <<: *preprocessingConfigFile
+          segments:
+            - name: main
+              references:
+                - name: "singleReference"
+                  nextclade_dataset_name: nextstrain/orthoebolavirus/sudv
+                  nextclade_dataset_tag: "2025-09-24--07-29-03Z"
+                  genes: [NP, VP35, VP40, GP, sGP, ssGP, VP30, VP24, L]
+      - <<: *preprocessing
+        version:
+          - 25
         configFile:
           <<: *preprocessingConfigFile
           segments:
@@ -1828,6 +1860,34 @@ organisms:
       - <<: *preprocessing
         version:
           - 28
+        replicas: 1
+        configFile:
+          <<: *preprocessingConfigFile
+          segment_classification_method: "minimizer"
+          create_embl_file: false
+          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/dengue/minimizer.json"
+          segments:
+            - name: main
+              references:
+                - name: DENV-1
+                  nextclade_dataset_name: community/v-gen-lab/dengue/denv1
+                  nextclade_dataset_tag: 2025-09-09--12-13-13Z
+                  genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
+                - name: DENV-2
+                  nextclade_dataset_name: community/v-gen-lab/dengue/denv2
+                  nextclade_dataset_tag: 2025-09-09--12-13-13Z
+                  genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
+                - name: DENV-3
+                  nextclade_dataset_name: community/v-gen-lab/dengue/denv3
+                  nextclade_dataset_tag: 2025-09-09--12-13-13Z
+                  genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
+                - name: DENV-4
+                  nextclade_dataset_name: community/v-gen-lab/dengue/denv4
+                  nextclade_dataset_tag: 2025-09-09--12-13-13Z
+                  genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
+      - <<: *preprocessing
+        version:
+          - 29
         replicas: 1
         configFile:
           <<: *preprocessingConfigFile
@@ -2042,6 +2102,18 @@ organisms:
                 nextclade_dataset_name: nextstrain/wnv/all-lineages
                 nextclade_dataset_tag: "2026-03-04--12-40-26Z"
                 genes: [capsid, prM, env, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
+      - <<: *preprocessing
+        version:
+          - 26
+        configFile:
+          <<: *preprocessingConfigFile
+          segments:
+            - name: main
+              references:
+              - name: singleReference
+                nextclade_dataset_name: nextstrain/wnv/all-lineages
+                nextclade_dataset_tag: "2026-03-04--12-40-26Z"
+                genes: [capsid, prM, env, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
     ingest:
       <<: *ingest
       configFile:
@@ -2140,6 +2212,29 @@ organisms:
       - <<: *preprocessing
         version:
           - 21
+        configFile:
+          <<: *preprocessingConfigFile
+          log_level: DEBUG
+          segments:
+            - name: L
+              references:
+              - name: singleReference
+                nextclade_dataset_name: community/pathoplexus/cchfv/L
+                genes: [RdRp]
+            - name: M
+              references:
+              - name: singleReference
+                nextclade_dataset_name: community/pathoplexus/cchfv/M
+                genes: [GPC]
+            - name: S
+              references:
+              - name: singleReference
+                nextclade_dataset_name: community/pathoplexus/cchfv/S
+                genes: [NP]
+          segment_classification_method: "align"
+      - <<: *preprocessing
+        version:
+          - 22
         configFile:
           <<: *preprocessingConfigFile
           log_level: DEBUG
@@ -2476,15 +2571,15 @@ organisms:
                   - OPG208
                   - OPG209
                   - OPG210
-      # - <<: *mpoxPreprocessing
-      #   replicas: 3
-      #   version:
-      #     - 18
-      #   configFile:
-      #     <<: *preprocessingConfigFile
-      #     batch_size: 10
-      #     segments:
-      #       - <<: *mpoxDataset
+      - <<: *mpoxPreprocessing
+        replicas: 3
+        version:
+          - 19
+        configFile:
+          <<: *preprocessingConfigFile
+          batch_size: 10
+          segments:
+            - <<: *mpoxDataset
     ingest:
       <<: *ingest
       configFile:
@@ -2924,6 +3019,23 @@ organisms:
                   - rsv-a
           require_nextclade_sort_match: true
           minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
+      - <<: *preprocessing
+        version:
+          - 20
+        replicas: 1
+        configFile:
+          <<: *preprocessingConfigFile
+          segments:
+            - name: main
+              references:
+              - name: singleReference
+                genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
+                nextclade_dataset_name: "nextstrain/rsv/a/EPI_ISL_412866"
+                nextclade_dataset_tag: "2025-08-25--09-00-35Z"
+                accepted_dataset_matches: 
+                  - rsv-a
+          require_nextclade_sort_match: true
+          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
     ingest:
       <<: *ingest
       configFile:
@@ -3040,6 +3152,23 @@ organisms:
                 genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
           require_nextclade_sort_match: true
           minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
+      - <<: *preprocessing
+        version:
+          - 21
+        replicas: 1
+        configFile:
+          <<: *preprocessingConfigFile
+          segments:
+            - name: main
+              references:
+              - name: singleReference
+                nextclade_dataset_name: "nextstrain/rsv/b/EPI_ISL_1653999"
+                nextclade_dataset_tag: "2025-08-25--09-00-35Z"
+                accepted_dataset_matches:
+                  - rsv-b
+                genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
+          require_nextclade_sort_match: true
+          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
     ingest:
       <<: *ingest
       configFile:
@@ -3132,6 +3261,19 @@ organisms:
         replicas: 1
         version:
           - 21
+        configFile:
+          <<: *preprocessingConfigFile
+          segments:
+            - name: main
+              references:
+              - name: singleReference
+                nextclade_dataset_name: "nextstrain/hmpv/all-clades/NC_039199"
+                nextclade_dataset_tag: "2025-04-25--12-24-24Z"
+                genes: [ "F", "G", "L", "M", "N", "M2-1", "M2-2", "P", "SH" ]
+      - <<: *preprocessing
+        replicas: 1
+        version:
+          - 22
         configFile:
           <<: *preprocessingConfigFile
           segments:
@@ -3238,6 +3380,19 @@ organisms:
                 nextclade_dataset_name: "nextstrain/measles/genome/WHO-2012"
                 nextclade_dataset_tag: "2025-08-11--19-06-01Z"
                 genes: [ "C", "F", "H", "L", "M", "N", "P", "V" ]
+      - <<: *preprocessing
+        version:
+          - 26
+        replicas: 1
+        configFile:
+          <<: *preprocessingConfigFile
+          segments:
+            - name: main
+              references:
+              - name: singleReference
+                nextclade_dataset_name: "nextstrain/measles/genome/WHO-2012"
+                nextclade_dataset_tag: "2025-08-11--19-06-01Z"
+                genes: [ "C", "F", "H", "L", "M", "N", "P", "V" ]
     ingest:
       <<: *ingest
       configFile:
@@ -3317,6 +3472,19 @@ organisms:
       - <<: *preprocessing
         version:
           - 22
+        replicas: 1
+        configFile:
+          <<: *preprocessingConfigFile
+          segments:
+            - name: main
+              references:
+              - name: singleReference
+                nextclade_dataset_name: "community/genspectrum/marburg/HK1980/all-lineages"
+                nextclade_dataset_tag: "2025-09-09--12-13-13Z"
+                genes: [GP, L, NP, VP24, VP30, VP35, VP40]
+      - <<: *preprocessing
+        version:
+          - 23
         replicas: 1
         configFile:
           <<: *preprocessingConfigFile
@@ -3448,6 +3616,18 @@ organisms:
       - <<: *preprocessing
         version:
           - 27
+        configFile:
+          <<: *preprocessingConfigFile
+          segments:
+            - name: main
+              references:
+              - name: singleReference 
+                nextclade_dataset_name: community/pathoplexus/yellow-fever-virus
+                genes: ["C", "prM", "M", "E", "NS1", "NS2a", "NS2b", "NS3", "NS4a", "2K", "NS4b", "RdRPol"]
+          nextclade_dataset_server: https://raw.githubusercontent.com/maverbiest/nextclade_data/yellow-fever-virus/data_output
+      - <<: *preprocessing
+        version:
+          - 28
         configFile:
           <<: *preprocessingConfigFile
           segments:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1888,7 +1888,7 @@ organisms:
       - <<: *preprocessing
         version:
           - 29
-        replicas: 1
+        replicas: 3
         configFile:
           <<: *preprocessingConfigFile
           segment_classification_method: "minimizer"
@@ -3022,7 +3022,7 @@ organisms:
       - <<: *preprocessing
         version:
           - 20
-        replicas: 1
+        replicas: 2
         configFile:
           <<: *preprocessingConfigFile
           segments:
@@ -3155,7 +3155,7 @@ organisms:
       - <<: *preprocessing
         version:
           - 21
-        replicas: 1
+        replicas: 2
         configFile:
           <<: *preprocessingConfigFile
           segments:


### PR DESCRIPTION
We want to add a `host` field to the `unprocessed_data` jsonb for legacy direct submissions (where the `host` field didn't exist yet).

We will backfill `host` from hostTaxonId; if that doesn't exist, we will use `hostNameScientific`; if that doesn't exist, we set it to null.

We will run this DB surgery on staging:
```sql
UPDATE public.sequence_entries
SET unprocessed_data = jsonb_set(
    unprocessed_data,
    '{metadata,host}',
    COALESCE(
        unprocessed_data->'metadata'->'hostTaxonId',
        unprocessed_data->'metadata'->'hostNameScientific',
        'null'::jsonb
    )
)
WHERE group_id != 1;
```

After that, we will bump the prepro pipeline versions by pointing staging to this PR, which will reprocess all sequences. Once we're sure this doesn't break anything, we will run the DB surgery on production.