### PR TITLE
Feature-editing data use terms

### DIFF
--- a/monorepo/website/src/pages/docs/how-to/edit-data-use-terms.mdx
+++ b/monorepo/website/src/pages/docs/how-to/edit-data-use-terms.mdx
@@ -33,7 +33,7 @@ In order to this;
 To change data use terms for a single sequence;
 - Navigate to the released sequences portal
 - Select the sequence you wish to change data use terms for by clicking on it directly.
-- Scroll to the bottom of the page, and select `edit data use terms`. A context menu will appear where you can choose open to make the sequence open. 
+- Scroll to the bottom of the page, and select `edit data use terms`. A context menu will appear where you can choose `open` to make the sequence open. 
 
 
 

--- a/monorepo/website/src/pages/docs/how-to/edit-data-use-terms.mdx
+++ b/monorepo/website/src/pages/docs/how-to/edit-data-use-terms.mdx
@@ -1,0 +1,39 @@
+---
+layout: ../../../layouts/DocLayout.astro
+title: "Editing data use terms for submitted data"
+order: 46
+---
+Once data has been submitted to Pathoplexus under restricted data use terms, it can be adjusted from restricted to open
+if the data submiter wishes to do so. This action can be performed in a batch for a group of released sequences, a selected 
+proportion of the released sequences, as well as a single sequence. Below are the steps you can follow to change data use terms 
+for your released data.
+
+## Changing data use terms for all released sequences
+- Log in to your account using the crenditials you used to submit the data.
+- Select the organism for which you want to update the data use terms. Remember, you can only
+change the terms from restricted to open-not the other way round.
+- Click the Submit Sequences button in the top menu bar to be redirected to the sumission portal.
+- Choose View from the submission portal menu (bottom right corner-one of the four buttons). This will display 
+your recently submitted or released sequences. A prompt may appear at the top showing how many sequences you recently released.
+
+Note: If you cannot see the sequences you wish to make open or edit, you may not have selected the correct submitting group.
+Change this by using the dropdown menu of your current groups in the top left corner while on the released sequences page.
+
+- Select Edit Data Use Terms (for all sequences) from the top-right section above the sequence metadata fields. A context menu will appear
+where you can choose Open to make all sequences open.
+
+## Changing data use terms for a selected proportion of sequences 
+Similarly, you can change data use terms for a selected proportion of sequences.
+In order to this;
+- You will have to identify the sequences for which you wish to change the data use terms and select them by checking the 
+check box on the left before the Accession ID.
+- Select Edit Data Use Terms (for selected sequences) from the top-right section above the sequence metadata fields.
+
+## Changing data use terms for a single sequence
+To change data use terms for a single sequence;
+- Navigate to the released sequences portal
+- Select the sequence you wish to change data use terms for by clicking on it directly.
+- Scroll to the bottom of the page, and select edit data use terms. A context menu will appear where you can choose open to make the sequence open. 
+
+
+

--- a/monorepo/website/src/pages/docs/how-to/edit-data-use-terms.mdx
+++ b/monorepo/website/src/pages/docs/how-to/edit-data-use-terms.mdx
@@ -9,31 +9,31 @@ proportion of the released sequences, as well as a single sequence. Below are th
 for your released data.
 
 ## Changing data use terms for all released sequences
-- Log in to your account using the crenditials you used to submit the data.
-- Select the organism for which you want to update the data use terms. Remember, you can only
-change the terms from restricted to open-not the other way round.
-- Click the Submit Sequences button in the top menu bar to be redirected to the sumission portal.
-- Choose View from the submission portal menu (bottom right corner-one of the four buttons). This will display 
+- **Log in** to your account using the crenditials you used to submit the data.
+- **Select** the organism for which you want to update the data use terms. Remember, you can only
+change the terms from `restricted` to `open`-not the other way round.
+- **Click** the Submit Sequences button in the top menu bar to be redirected to the sumission portal.
+- Choose **View** from the submission portal menu (bottom right corner-one of the four buttons). This will display 
 your recently submitted or released sequences. A prompt may appear at the top showing how many sequences you recently released.
 
-Note: If you cannot see the sequences you wish to make open or edit, you may not have selected the correct submitting group.
+**Note:** If you cannot see the sequences you wish to make open or edit, you may not have selected the correct submitting group.
 Change this by using the dropdown menu of your current groups in the top left corner while on the released sequences page.
 
-- Select Edit Data Use Terms (for all sequences) from the top-right section above the sequence metadata fields. A context menu will appear
-where you can choose Open to make all sequences open.
+- Select `Edit Data Use Terms (for all sequences)` from the top-right section above the sequence metadata fields. A context menu will appear
+where you can choose **Open** to make all sequences open.
 
 ## Changing data use terms for a selected proportion of sequences 
 Similarly, you can change data use terms for a selected proportion of sequences.
 In order to this;
 - You will have to identify the sequences for which you wish to change the data use terms and select them by checking the 
-check box on the left before the Accession ID.
-- Select Edit Data Use Terms (for selected sequences) from the top-right section above the sequence metadata fields.
+`check box` on the left before the Accession ID.
+- Select `Edit Data Use Terms (for selected sequences)` from the top-right section above the sequence metadata fields.
 
 ## Changing data use terms for a single sequence
 To change data use terms for a single sequence;
 - Navigate to the released sequences portal
 - Select the sequence you wish to change data use terms for by clicking on it directly.
-- Scroll to the bottom of the page, and select edit data use terms. A context menu will appear where you can choose open to make the sequence open. 
+- Scroll to the bottom of the page, and select `edit data use terms`. A context menu will appear where you can choose open to make the sequence open. 
 
 
 


### PR DESCRIPTION
I have added a page with steps on editing data use terms from `restricted` to `open`.  Some users had difficulties finding this guidance and commented over slack. Quoted text slack conversation below.
>I have tried looking up on how I can change the restricted use to open data in the docs but i can't find anything of help  