### PR TITLE
Remove discussion.pathoplexus links

### DIFF
--- a/monorepo/website/src/pages/news/2024-08-27-hello-world.mdx
+++ b/monorepo/website/src/pages/news/2024-08-27-hello-world.mdx
@@ -44,7 +44,7 @@ In addition to allowing submitters to restrict the use of their data for a perio
 
 Pathoplexus is an open source project. All the code that powers our software is available on [GitHub](https://github.com/pathoplexus/pathoplexus). We welcome bug reports to that repository, and would be especially grateful to volunteers who want to make improvements to the code, or to help add new features.
 
-Our belief is that core scholarly infrastructure should be open and should welcome feedback. We are very keen to engage with the community: you can get involved on our [Discussion board](https://discussion.pathoplexus.org) and discuss anything related to sequence submission, retrieval, and much more. You can also connect with us on [Mastodon](https://mstdn.science/@pathoplexus), [Bluesky](https://bsky.app/profile/pathoplexus.org), or [Twitter](https://x.com/pathoplexus) .
+Our belief is that core scholarly infrastructure should be open and should welcome feedback. We are very keen to engage with the community: on [GitHub](https://github.com/pathoplexus/pathoplexus), and much more. You can also connect with us on [Mastodon](https://mstdn.science/@pathoplexus), [Bluesky](https://bsky.app/profile/pathoplexus.org), or [Twitter](https://x.com/pathoplexus) .
 
 ## Transparency and governance
 

--- a/monorepo/website/src/pages/news/2024-08-27-hello-world.mdx
+++ b/monorepo/website/src/pages/news/2024-08-27-hello-world.mdx
@@ -44,7 +44,7 @@ In addition to allowing submitters to restrict the use of their data for a perio
 
 Pathoplexus is an open source project. All the code that powers our software is available on [GitHub](https://github.com/pathoplexus/pathoplexus). We welcome bug reports to that repository, and would be especially grateful to volunteers who want to make improvements to the code, or to help add new features.
 
-Our belief is that core scholarly infrastructure should be open and should welcome feedback. We are very keen to engage with the community: on [GitHub](https://github.com/pathoplexus/pathoplexus), and much more. You can also connect with us on [Mastodon](https://mstdn.science/@pathoplexus), [Bluesky](https://bsky.app/profile/pathoplexus.org), or [Twitter](https://x.com/pathoplexus) .
+Our belief is that core scholarly infrastructure should be open and should welcome feedback. We are very keen to engage with the community! If you have any questions or comments, please get in touch on [GitHub](https://github.com/pathoplexus/pathoplexus), or send us an email at contact@pathoplexus.org. You can also connect with us on [Mastodon](https://mstdn.science/@pathoplexus), [Bluesky](https://bsky.app/profile/pathoplexus.org), or [Twitter](https://x.com/pathoplexus) .
 
 ## Transparency and governance
 


### PR DESCRIPTION
Revised community engagement section for clarity and emphasis on GitHub involvement.

🚀 Preview: Add `preview` label to enable