### PR TITLE
feat(ops): adjust resource requests for prod - lower cpu baseline for smaller silo/lapis instances

### DIFF
--- a/loculus_values/environment_specific_values/production.yaml
+++ b/loculus_values/environment_specific_values/production.yaml
@@ -153,7 +153,7 @@ resources:
           memory: "2Gi"
           cpu: "1000m"
         limits:
-          memory: "5Gi"
+          memory: "2Gi"
       silo-importer:
         requests:
           memory: "3Gi"

--- a/loculus_values/environment_specific_values/production.yaml
+++ b/loculus_values/environment_specific_values/production.yaml
@@ -153,7 +153,7 @@ resources:
           memory: "2Gi"
           cpu: "1000m"
         limits:
-          memory: "2Gi"
+          memory: "5Gi"
       silo-importer:
         requests:
           memory: "3Gi"
@@ -172,7 +172,7 @@ resources:
           memory: "220Mi"
           cpu: "250m"
         limits:
-          memory: "5Gi"
+          memory: "2Gi"
     yellow-fever:
       silo:
         requests:
@@ -185,7 +185,7 @@ resources:
           memory: "220Mi"
           cpu: "250m"
         limits:
-          memory: "5Gi"
+          memory: "2Gi"
     ebola-sudan:
       silo:
         requests:
@@ -198,7 +198,7 @@ resources:
           memory: "220Mi"
           cpu: "250m"
         limits:
-          memory: "5Gi"
+          memory: "2Gi"
 defaultResources:
   requests:
     memory: "200Mi"

--- a/loculus_values/environment_specific_values/production.yaml
+++ b/loculus_values/environment_specific_values/production.yaml
@@ -112,7 +112,7 @@ resources:
       memory: "3Gi"
   silo:
     requests:
-      memory: "1Gi"
+      memory: "2Gi"
       cpu: "500m"
     limits:
       memory: "2Gi"
@@ -163,7 +163,7 @@ resources:
     marburg:
       silo:
         requests:
-          memory: "500Mi"
+          memory: "1Gi"
           cpu: "250m"
         limits:
           memory: "1Gi"
@@ -176,7 +176,7 @@ resources:
     yellow-fever:
       silo:
         requests:
-          memory: "500Mi"
+          memory: "1Gi"
           cpu: "250m"
         limits:
           memory: "1Gi"
@@ -189,7 +189,7 @@ resources:
     ebola-sudan:
       silo:
         requests:
-          memory: "500Mi"
+          memory: "1Gi"
           cpu: "250m"
         limits:
           memory: "1Gi"

--- a/loculus_values/environment_specific_values/production.yaml
+++ b/loculus_values/environment_specific_values/production.yaml
@@ -112,14 +112,14 @@ resources:
       memory: "3Gi"
   silo:
     requests:
-      memory: "2Gi"
-      cpu: "1000m"
+      memory: "1Gi"
+      cpu: "500m"
     limits:
       memory: "2Gi"
   lapis:
     requests:
       memory: "220Mi"
-      cpu: "1000m"
+      cpu: "500m"
     limits:
       memory: "5Gi"
   silo-importer:
@@ -160,6 +160,45 @@ resources:
           cpu: "1000m"
         limits:
           memory: "3Gi"
+    marburg:
+      silo:
+        requests:
+          memory: "500Mi"
+          cpu: "250m"
+        limits:
+          memory: "1Gi"
+      lapis:
+        requests:
+          memory: "220Mi"
+          cpu: "250m"
+        limits:
+          memory: "5Gi"
+    yellow-fever:
+      silo:
+        requests:
+          memory: "500Mi"
+          cpu: "250m"
+        limits:
+          memory: "1Gi"
+      lapis:
+        requests:
+          memory: "220Mi"
+          cpu: "250m"
+        limits:
+          memory: "5Gi"
+    ebola-sudan:
+      silo:
+        requests:
+          memory: "500Mi"
+          cpu: "250m"
+        limits:
+          memory: "1Gi"
+      lapis:
+        requests:
+          memory: "220Mi"
+          cpu: "250m"
+        limits:
+          memory: "5Gi"
 defaultResources:
   requests:
     memory: "200Mi"


### PR DESCRIPTION
Top pods sorted by the ratio between requested/actually used memory. For the smaller organisms such as marburg, ebola-sudan and yellow-fever we request almost 600times that of what we actually use. For medium sized organisms this is more like 200times:
<img width="3097" height="1065" alt="image" src="https://github.com/user-attachments/assets/052fd303-e3af-47ec-a0c8-0586f88139d9" />


For memory its around 30times that of which we actually use:
<img width="3097" height="1065" alt="image" src="https://github.com/user-attachments/assets/c484387c-4216-4ed6-b07d-08d690c3c20a" />


Code can be viewed in Grafana: https://grafana.pathoplexus.org/d/cfl58hc2l83cwb/requested-resources-vs-used-resources?orgId=1


