### PR TITLE
feat(deployments): reduce defaultResources limits and ingest requests (for non prod/staging)

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -3633,7 +3633,7 @@ resources:
       cpu: "50m"
     limits:
       cpu: "200m"
-      memory: "1Gi"
+      memory: "10Gi"
   backend:
     requests:
       memory: "640Mi"

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -3619,8 +3619,8 @@ defaultResources:
     memory: "10Mi"
     cpu: "10m"
   limits:
-    memory: "1Gi"
-    cpu: "1000m"
+    memory: "200Mi"
+    cpu: "500m"
 
 taxonomyService:
   dbVersion: "ncbi_taxonomy_latest"
@@ -3629,11 +3629,11 @@ taxonomyService:
 resources:
   ingest:
     requests:
-      memory: "1Gi"
+      memory: "200Mi"
       cpu: "50m"
     limits:
       cpu: "200m"
-      memory: "10Gi"
+      memory: "1Gi"
   backend:
     requests:
       memory: "640Mi"

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -3619,8 +3619,8 @@ defaultResources:
     memory: "10Mi"
     cpu: "10m"
   limits:
-    memory: "200Mi"
-    cpu: "500m"
+    memory: "1Gi"
+    cpu: "1000m"
 
 taxonomyService:
   dbVersion: "ncbi_taxonomy_latest"


### PR DESCRIPTION
Note that staging and prod overwrite the `defaultResources` and the ingest resources are overwritten by production. These changes will only affect previews, main, the demo and staging ingest requests. Ingest pods will use the limit if it is available (this causes the memory peaks - see below).

Memory peaks for mpox on main:
<img width="1576" height="570" alt="image" src="https://github.com/user-attachments/assets/a463149a-e5e6-4ddf-a315-0aec6c4948c0" />

mpox memor with lower limit:
<img width="1576" height="570" alt="image" src="https://github.com/user-attachments/assets/5832c776-ed06-4e31-a752-55056b340653" />

🚀 Preview: https://preview-limits.pathoplexus.org