### PR TITLE
fix: remove ncbiReleaseDate from default view in search table for Dengue

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1875,7 +1875,6 @@ organisms:
         tableColumns:
           - sampleCollectionDate
           - earliestReleaseDate
-          - ncbiReleaseDate
           - geoLocCountry
           - authors
           - authorAffiliations


### PR DESCRIPTION
fixes #921

Dengue is the only place we show ncbiReleaseDate in search table by default.

The field is mostly redundant with earliest release date, hence not included in all other organisms. Removing for consistency.

@maverbiest as you configured that organism, just checking I'm not missing a reason for including it here but not elsewhere.