### PR TITLE
Add Andes Virus [Hantavirus] organism

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2146,7 +2146,7 @@ organisms:
               sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/env.fasta]]"
             - name: prM
               sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/prM.fasta]]"
-  hanta-andes:
+  andv:
     <<: *defaultOrganismConfig
     schema:
       <<: *schema
@@ -2155,20 +2155,20 @@ organisms:
         maxSequencesPerEntry: 3
       organismName: "Andes Virus [Hantavirus]"
       nucleotideSequences: [L, M, S]
-      image: "https://pathoplexus.github.io/reference_store/hanta-andes/images/viridis_invert.png"
+      image: "https://pathoplexus.github.io/reference_store/andv/images/viridis_invert.png"
       linkOuts:
         - name: "Nextclade (L)"
           category: "Nextclade"
           maxNumberOfRecommendedEntries: 3000
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:L+rich|fasta]}}&dataset-name=hanta-andes/L&dataset-server=https://pathoplexus.github.io/reference_store/hanta-andes/nextclade_data"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:L+rich|fasta]}}&dataset-name=andv/L&dataset-server=https://pathoplexus.github.io/reference_store/andv/nextclade_data"
         - name: "Nextclade (M)"
           category: "Nextclade"
           maxNumberOfRecommendedEntries: 5000
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:M+rich|fasta]}}&dataset-name=hanta-andes/M&dataset-server=https://pathoplexus.github.io/reference_store/hanta-andes/nextclade_data"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:M+rich|fasta]}}&dataset-name=andv/M&dataset-server=https://pathoplexus.github.io/reference_store/andv/nextclade_data"
         - name: "Nextclade (S)"
           category: "Nextclade"
           maxNumberOfRecommendedEntries: 10000
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:S+rich|fasta]}}&dataset-name=hanta-andes/S&dataset-server=https://pathoplexus.github.io/reference_store/hanta-andes/nextclade_data"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:S+rich|fasta]}}&dataset-name=andv/S&dataset-server=https://pathoplexus.github.io/reference_store/andv/nextclade_data"
         - name: "Country map"
           category: "Other"
           maxNumberOfRecommendedEntries: 45000
@@ -2198,22 +2198,22 @@ organisms:
           taxon_id: 1980456
           scientific_name: "Andes Virus"
           molecule_type: "genomic RNA"
-          nextclade_dataset_server: "https://pathoplexus.github.io/reference_store/hanta-andes/nextclade_data"
+          nextclade_dataset_server: "https://pathoplexus.github.io/reference_store/andv/nextclade_data"
           segments:
             - name: L
               references:
                 - name: singleReference
-                  nextclade_dataset_name: hanta-andes/L
+                  nextclade_dataset_name: andv/L
                   genes: [RdRp]
             - name: M
               references:
                 - name: singleReference
-                  nextclade_dataset_name: hanta-andes/M
+                  nextclade_dataset_name: andv/M
                   genes: [GPC]
             - name: S
               references:
                 - name: singleReference
-                  nextclade_dataset_name: hanta-andes/S
+                  nextclade_dataset_name: andv/S
                   genes: ["N", NSs]
     ingest:
       <<: *ingest
@@ -2223,7 +2223,7 @@ organisms:
         calculate_groups_override_json: true
         segment_identification:
           method: "minimizer"
-          minimizer_url: "https://pathoplexus.github.io/reference_store/hanta-andes/segment-minimizer.json"
+          minimizer_url: "https://pathoplexus.github.io/reference_store/andv/segment-minimizer.json"
           minimizer_parser: ["segment"]
     enaDeposition:
       singleReference:
@@ -2235,29 +2235,29 @@ organisms:
       - name: L
         references:
           - name: singleReference
-            sequence: "[[URL:https://pathoplexus.github.io/reference_store/hanta-andes/NC_003468.2.fasta]]"
+            sequence: "[[URL:https://pathoplexus.github.io/reference_store/andv/NC_003468.2.fasta]]"
             insdcAccessionFull: NC_003468.2
             genes:
               - name: RdRp
-                sequence: "[[URL:https://pathoplexus.github.io/reference_store/hanta-andes/genes/RdRp.fasta]]"
+                sequence: "[[URL:https://pathoplexus.github.io/reference_store/andv/genes/RdRp.fasta]]"
       - name: M
         references:
           - name: singleReference
-            sequence: "[[URL:https://pathoplexus.github.io/reference_store/hanta-andes/NC_003467.2.fasta]]"
+            sequence: "[[URL:https://pathoplexus.github.io/reference_store/andv/NC_003467.2.fasta]]"
             insdcAccessionFull: NC_003467.2
             genes:
               - name: GPC
-                sequence: "[[URL:https://pathoplexus.github.io/reference_store/hanta-andes/genes/GPC.fasta]]"
+                sequence: "[[URL:https://pathoplexus.github.io/reference_store/andv/genes/GPC.fasta]]"
       - name: S
         references:
           - name: singleReference
-            sequence: "[[URL:https://pathoplexus.github.io/reference_store/hanta-andes/NC_003466.1.fasta]]"
+            sequence: "[[URL:https://pathoplexus.github.io/reference_store/andv/NC_003466.1.fasta]]"
             insdcAccessionFull: NC_003466.1
             genes:
               - name: "N"
-                sequence: "[[URL:https://pathoplexus.github.io/reference_store/hanta-andes/genes/N.fasta]]"
+                sequence: "[[URL:https://pathoplexus.github.io/reference_store/andv/genes/N.fasta]]"
               - name: NSs
-                sequence: "[[URL:https://pathoplexus.github.io/reference_store/hanta-andes/genes/NSs.fasta]]"
+                sequence: "[[URL:https://pathoplexus.github.io/reference_store/andv/genes/NSs.fasta]]"
   cchf:
     <<: *defaultOrganismConfig
     schema:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1556,7 +1556,6 @@ defaultOrganismConfig: &defaultOrganismConfig
       multiFieldSearches:
         - name: identifier
           displayName: Identifier (INSDC, etc.)
-          orderInSearchDisplay: 0
           fields:
             - accessionVersion
             - submissionId

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2146,6 +2146,118 @@ organisms:
               sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/env.fasta]]"
             - name: prM
               sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/prM.fasta]]"
+  andes-virus:
+    <<: *defaultOrganismConfig
+    schema:
+      <<: *schema
+      submissionDataTypes:
+        <<: *defaultSubmissionDataTypes
+        maxSequencesPerEntry: 3
+      organismName: "Andes virus"
+      nucleotideSequences: [L, M, S]
+      image: "https://raw.githubusercontent.com/loculus-project/agent_store/9607d5fb7772685222e1769ed32169db3351e2a4/andes-virus/images/copper_r.png"
+      linkOuts:
+        - name: "Nextclade (L)"
+          category: "Nextclade"
+          maxNumberOfRecommendedEntries: 3000
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:L+rich|fasta]}}&dataset-name=andes-virus/L&dataset-server=https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/nextclade_data"
+        - name: "Nextclade (M)"
+          category: "Nextclade"
+          maxNumberOfRecommendedEntries: 5000
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:M+rich|fasta]}}&dataset-name=andes-virus/M&dataset-server=https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/nextclade_data"
+        - name: "Nextclade (S)"
+          category: "Nextclade"
+          maxNumberOfRecommendedEntries: 10000
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:S+rich|fasta]}}&dataset-name=andes-virus/S&dataset-server=https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/nextclade_data"
+        - name: "Country map"
+          category: "Other"
+          maxNumberOfRecommendedEntries: 45000
+          url: "https://mapoplexus.genomium.org/?url={{[metadata]}}"
+      website:
+        <<: *website
+        tableColumns:
+          - sampleCollectionDate
+          - geoLocCountry
+          - geoLocAdmin1
+          - authors
+          - authorAffiliations
+          - earliestReleaseDate
+          - hostNameScientific
+          - length_M
+          - length_S
+          - length_L
+        defaultOrderBy: sampleCollectionDate
+        defaultOrder: descending
+    preprocessing:
+      - <<: *preprocessing
+        version:
+          - 1
+        configFile:
+          <<: *preprocessingConfigFile
+          create_embl_file: false
+          taxon_id: 1980456
+          scientific_name: "Andes virus"
+          molecule_type: "genomic RNA"
+          nextclade_dataset_server: "https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/nextclade_data"
+          segments:
+            - name: L
+              references:
+                - name: singleReference
+                  nextclade_dataset_name: andes-virus/L
+                  genes: [RdRp]
+            - name: M
+              references:
+                - name: singleReference
+                  nextclade_dataset_name: andes-virus/M
+                  genes: [GPC]
+            - name: S
+              references:
+                - name: singleReference
+                  nextclade_dataset_name: andes-virus/S
+                  genes: ["N", NSs]
+    ingest:
+      <<: *ingest
+      configFile:
+        <<: *defaultIngestConfigFile
+        taxon_id: 1980456
+        calculate_groups_override_json: true
+        segment_identification:
+          method: "minimizer"
+          minimizer_url: "https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/segment-minimizer.json"
+          minimizer_parser: ["segment"]
+    enaDeposition:
+      singleReference:
+        configFile:
+          taxon_id: 1980456
+          scientific_name: "Andes virus"
+          molecule_type: "genomic RNA"
+    referenceGenomes:
+      - name: L
+        references:
+          - name: singleReference
+            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/NC_003468.2.fasta]]"
+            insdcAccessionFull: NC_003468.2
+            genes:
+              - name: RdRp
+                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/genes/RdRp.fasta]]"
+      - name: M
+        references:
+          - name: singleReference
+            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/NC_003467.2.fasta]]"
+            insdcAccessionFull: NC_003467.2
+            genes:
+              - name: GPC
+                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/genes/GPC.fasta]]"
+      - name: S
+        references:
+          - name: singleReference
+            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/NC_003466.1.fasta]]"
+            insdcAccessionFull: NC_003466.1
+            genes:
+              - name: "N"
+                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/genes/N.fasta]]"
+              - name: NSs
+                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/genes/NSs.fasta]]"
   cchf:
     <<: *defaultOrganismConfig
     schema:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2153,7 +2153,7 @@ organisms:
       submissionDataTypes:
         <<: *defaultSubmissionDataTypes
         maxSequencesPerEntry: 3
-      organismName: "Andes virus"
+      organismName: "Andes Virus"
       nucleotideSequences: [L, M, S]
       image: "https://raw.githubusercontent.com/loculus-project/agent_store/eb5ead95768351c5ee1576065a731bb32e6502f2/andes-virus/images/viridis_invert.png"
       linkOuts:
@@ -2196,7 +2196,7 @@ organisms:
           <<: *preprocessingConfigFile
           create_embl_file: false
           taxon_id: 1980456
-          scientific_name: "Andes virus"
+          scientific_name: "Andes Virus"
           molecule_type: "genomic RNA"
           nextclade_dataset_server: "https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/nextclade_data"
           segments:
@@ -2229,7 +2229,7 @@ organisms:
       singleReference:
         configFile:
           taxon_id: 1980456
-          scientific_name: "Andes virus"
+          scientific_name: "Andes Virus"
           molecule_type: "genomic RNA"
     referenceGenomes:
       - name: L

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2155,20 +2155,20 @@ organisms:
         maxSequencesPerEntry: 3
       organismName: "Andes Virus [Hantavirus]"
       nucleotideSequences: [L, M, S]
-      image: "https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/images/viridis_invert.png"
+      image: "https://pathoplexus.github.io/reference_store/hanta-andes/images/viridis_invert.png"
       linkOuts:
         - name: "Nextclade (L)"
           category: "Nextclade"
           maxNumberOfRecommendedEntries: 3000
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:L+rich|fasta]}}&dataset-name=hanta-andes/L&dataset-server=https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/nextclade_data"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:L+rich|fasta]}}&dataset-name=hanta-andes/L&dataset-server=https://pathoplexus.github.io/reference_store/hanta-andes/nextclade_data"
         - name: "Nextclade (M)"
           category: "Nextclade"
           maxNumberOfRecommendedEntries: 5000
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:M+rich|fasta]}}&dataset-name=hanta-andes/M&dataset-server=https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/nextclade_data"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:M+rich|fasta]}}&dataset-name=hanta-andes/M&dataset-server=https://pathoplexus.github.io/reference_store/hanta-andes/nextclade_data"
         - name: "Nextclade (S)"
           category: "Nextclade"
           maxNumberOfRecommendedEntries: 10000
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:S+rich|fasta]}}&dataset-name=hanta-andes/S&dataset-server=https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/nextclade_data"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:S+rich|fasta]}}&dataset-name=hanta-andes/S&dataset-server=https://pathoplexus.github.io/reference_store/hanta-andes/nextclade_data"
         - name: "Country map"
           category: "Other"
           maxNumberOfRecommendedEntries: 45000
@@ -2198,7 +2198,7 @@ organisms:
           taxon_id: 1980456
           scientific_name: "Andes Virus"
           molecule_type: "genomic RNA"
-          nextclade_dataset_server: "https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/nextclade_data"
+          nextclade_dataset_server: "https://pathoplexus.github.io/reference_store/hanta-andes/nextclade_data"
           segments:
             - name: L
               references:
@@ -2223,7 +2223,7 @@ organisms:
         calculate_groups_override_json: true
         segment_identification:
           method: "minimizer"
-          minimizer_url: "https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/segment-minimizer.json"
+          minimizer_url: "https://pathoplexus.github.io/reference_store/hanta-andes/segment-minimizer.json"
           minimizer_parser: ["segment"]
     enaDeposition:
       singleReference:
@@ -2235,29 +2235,29 @@ organisms:
       - name: L
         references:
           - name: singleReference
-            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/NC_003468.2.fasta]]"
+            sequence: "[[URL:https://pathoplexus.github.io/reference_store/hanta-andes/NC_003468.2.fasta]]"
             insdcAccessionFull: NC_003468.2
             genes:
               - name: RdRp
-                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/genes/RdRp.fasta]]"
+                sequence: "[[URL:https://pathoplexus.github.io/reference_store/hanta-andes/genes/RdRp.fasta]]"
       - name: M
         references:
           - name: singleReference
-            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/NC_003467.2.fasta]]"
+            sequence: "[[URL:https://pathoplexus.github.io/reference_store/hanta-andes/NC_003467.2.fasta]]"
             insdcAccessionFull: NC_003467.2
             genes:
               - name: GPC
-                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/genes/GPC.fasta]]"
+                sequence: "[[URL:https://pathoplexus.github.io/reference_store/hanta-andes/genes/GPC.fasta]]"
       - name: S
         references:
           - name: singleReference
-            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/NC_003466.1.fasta]]"
+            sequence: "[[URL:https://pathoplexus.github.io/reference_store/hanta-andes/NC_003466.1.fasta]]"
             insdcAccessionFull: NC_003466.1
             genes:
               - name: "N"
-                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/genes/N.fasta]]"
+                sequence: "[[URL:https://pathoplexus.github.io/reference_store/hanta-andes/genes/N.fasta]]"
               - name: NSs
-                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/genes/NSs.fasta]]"
+                sequence: "[[URL:https://pathoplexus.github.io/reference_store/hanta-andes/genes/NSs.fasta]]"
   cchf:
     <<: *defaultOrganismConfig
     schema:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1556,6 +1556,7 @@ defaultOrganismConfig: &defaultOrganismConfig
       multiFieldSearches:
         - name: identifier
           displayName: Identifier (INSDC, etc.)
+          orderInSearchDisplay: -10000
           fields:
             - accessionVersion
             - submissionId

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2155,7 +2155,7 @@ organisms:
         maxSequencesPerEntry: 3
       organismName: "Andes virus"
       nucleotideSequences: [L, M, S]
-      image: "https://raw.githubusercontent.com/loculus-project/agent_store/9607d5fb7772685222e1769ed32169db3351e2a4/andes-virus/images/copper_r.png"
+      image: "https://raw.githubusercontent.com/loculus-project/agent_store/eb5ead95768351c5ee1576065a731bb32e6502f2/andes-virus/images/viridis_invert.png"
       linkOuts:
         - name: "Nextclade (L)"
           category: "Nextclade"

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1553,6 +1553,18 @@ defaultOrganismConfig: &defaultOrganismConfig
         - length
       defaultOrderBy: sampleCollectionDate
       defaultOrder: descending
+      multiFieldSearches:
+        - name: identifier
+          displayName: Identifier (INSDC, etc.)
+          orderInSearchDisplay: 0
+          fields:
+            - accessionVersion
+            - submissionId
+            - insdcAccessionFull
+            - bioprojectAccession
+            - gcaAccession
+            - biosampleAccession
+            - insdcRawReadsAccession
     extraInputFields:
       - &hostConfig
         name: host

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2146,29 +2146,29 @@ organisms:
               sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/env.fasta]]"
             - name: prM
               sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/west-nile/prM.fasta]]"
-  andes-virus:
+  hanta-andes:
     <<: *defaultOrganismConfig
     schema:
       <<: *schema
       submissionDataTypes:
         <<: *defaultSubmissionDataTypes
         maxSequencesPerEntry: 3
-      organismName: "Andes Virus"
+      organismName: "Andes Virus [Hantavirus]"
       nucleotideSequences: [L, M, S]
-      image: "https://raw.githubusercontent.com/loculus-project/agent_store/eb5ead95768351c5ee1576065a731bb32e6502f2/andes-virus/images/viridis_invert.png"
+      image: "https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/images/viridis_invert.png"
       linkOuts:
         - name: "Nextclade (L)"
           category: "Nextclade"
           maxNumberOfRecommendedEntries: 3000
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:L+rich|fasta]}}&dataset-name=andes-virus/L&dataset-server=https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/nextclade_data"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:L+rich|fasta]}}&dataset-name=hanta-andes/L&dataset-server=https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/nextclade_data"
         - name: "Nextclade (M)"
           category: "Nextclade"
           maxNumberOfRecommendedEntries: 5000
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:M+rich|fasta]}}&dataset-name=andes-virus/M&dataset-server=https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/nextclade_data"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:M+rich|fasta]}}&dataset-name=hanta-andes/M&dataset-server=https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/nextclade_data"
         - name: "Nextclade (S)"
           category: "Nextclade"
           maxNumberOfRecommendedEntries: 10000
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:S+rich|fasta]}}&dataset-name=andes-virus/S&dataset-server=https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/nextclade_data"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:S+rich|fasta]}}&dataset-name=hanta-andes/S&dataset-server=https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/nextclade_data"
         - name: "Country map"
           category: "Other"
           maxNumberOfRecommendedEntries: 45000
@@ -2198,22 +2198,22 @@ organisms:
           taxon_id: 1980456
           scientific_name: "Andes Virus"
           molecule_type: "genomic RNA"
-          nextclade_dataset_server: "https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/nextclade_data"
+          nextclade_dataset_server: "https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/nextclade_data"
           segments:
             - name: L
               references:
                 - name: singleReference
-                  nextclade_dataset_name: andes-virus/L
+                  nextclade_dataset_name: hanta-andes/L
                   genes: [RdRp]
             - name: M
               references:
                 - name: singleReference
-                  nextclade_dataset_name: andes-virus/M
+                  nextclade_dataset_name: hanta-andes/M
                   genes: [GPC]
             - name: S
               references:
                 - name: singleReference
-                  nextclade_dataset_name: andes-virus/S
+                  nextclade_dataset_name: hanta-andes/S
                   genes: ["N", NSs]
     ingest:
       <<: *ingest
@@ -2223,7 +2223,7 @@ organisms:
         calculate_groups_override_json: true
         segment_identification:
           method: "minimizer"
-          minimizer_url: "https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/segment-minimizer.json"
+          minimizer_url: "https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/segment-minimizer.json"
           minimizer_parser: ["segment"]
     enaDeposition:
       singleReference:
@@ -2235,29 +2235,29 @@ organisms:
       - name: L
         references:
           - name: singleReference
-            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/NC_003468.2.fasta]]"
+            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/NC_003468.2.fasta]]"
             insdcAccessionFull: NC_003468.2
             genes:
               - name: RdRp
-                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/genes/RdRp.fasta]]"
+                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/genes/RdRp.fasta]]"
       - name: M
         references:
           - name: singleReference
-            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/NC_003467.2.fasta]]"
+            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/NC_003467.2.fasta]]"
             insdcAccessionFull: NC_003467.2
             genes:
               - name: GPC
-                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/genes/GPC.fasta]]"
+                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/genes/GPC.fasta]]"
       - name: S
         references:
           - name: singleReference
-            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/NC_003466.1.fasta]]"
+            sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/NC_003466.1.fasta]]"
             insdcAccessionFull: NC_003466.1
             genes:
               - name: "N"
-                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/genes/N.fasta]]"
+                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/genes/N.fasta]]"
               - name: NSs
-                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/57a1a32725a6ba53cd557535e65076ad51b6d884/andes-virus/genes/NSs.fasta]]"
+                sequence: "[[URL:https://raw.githubusercontent.com/loculus-project/agent_store/ce0684238ed482577ec5ccd72093b6d32c392140/hanta-andes/genes/NSs.fasta]]"
   cchf:
     <<: *defaultOrganismConfig
     schema:

--- a/monorepo/website/src/pages/about/faq.mdx
+++ b/monorepo/website/src/pages/about/faq.mdx
@@ -240,6 +240,8 @@ We are grateful to use this [West Nile Virus image](https://pixnio.com/science/m
 
 We are grateful to use this [HMPV image](https://pmc.ncbi.nlm.nih.gov/articles/PMC3016779/figure/F3/) from Paul Chan.
 
+We are grateful to use this [Andes Virus image](https://www.frontiersin.org/journals/microbiology/articles/10.3389/fmicb.2019.02992/full), with light alterations to remove arrows and regrade colors.
+
 Lastly, we are grateful to use this [Mpox Virus image](https://cdn.who.int/media/images/default-source/health-topics/monkeypox/12763.tmb-1200v.jpg?sfvrsn=cd044fbd_3) from the WHO.
 
 </details>


### PR DESCRIPTION


## Summary

Adds Andes Virus [Hantavirus] as a Pathoplexus organism with three expected genome segments (`L`, `M`, and `S`). The configuration uses the Andes virus NCBI taxon ID `1980456` for ingest, preprocessing, and ENA deposition metadata.

The organism uses Andes virus reference assets staged through GitHub Pages in `pathoplexus/reference_store`:

- base URL: https://pathoplexus.github.io/reference_store/andv/
- `L`: `NC_003468.2`, gene `RdRp`
- `M`: `NC_003467.2`, gene `GPC`
- `S`: `NC_003466.1`, genes `N` and `NSs`

Preprocessing points at the minimal Andes virus Nextclade datasets in `reference_store`, and ingest uses the Andes-specific minimizer for segment identification. The organism image is also rehosted from `reference_store`.

This branch also adds a global multi-field identifier search named `Identifier (INSDC, etc.)` across organisms. It sets `orderInSearchDisplay: -10000` so the field appears near the top of the search UI.

## Validation

- `helm lint pathoplexus_app`
- `git diff --check`
- Ran Helm template checks locally for `demo`, `main`, `production`, and `staging` with the rebased Loculus chart values.
- Verified the configured `https://pathoplexus.github.io/reference_store/andv/...` asset URLs return HTTP 200, including individual Nextclade dataset files.


Preview: https://preview-andes-virus.pathoplexus.org