### PR TITLE
Add hint clarifying 'All Data' guidance for Andes Virus (Hantavirus)

### DIFF
--- a/monorepo/website/src/pages/about/terms-of-use/data-use-terms.mdx
+++ b/monorepo/website/src/pages/about/terms-of-use/data-use-terms.mdx
@@ -148,6 +148,10 @@ If a large number of submitters have contributed to the data, and you can answer
 
 Examples of what would be considered appropriate use of All Data:
 
+<div class="my-4 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-amber-900">
+  <p class="m-0"><strong>Hint:</strong> Note that for Andes Virus [Hantavirus], there are a small number of submitters from the current outbreak of interest, and so using the 'All data' dispensation would not be appropriate.</p>
+</div>
+
 - Using every available sequence in order to look at overarching sequence properties (ex: frequencies of a mutation) that are found globally or across continents
 - Using every sequence available in order to speak to only global/international trends with **no specific focus** on a country or region, especially one where a virus/variant/strain/clade originated or where a mutation of interest is only found
 


### PR DESCRIPTION
### Motivation
- Clarify that the "All data" dispensation is not appropriate for Andes Virus [Hantavirus] when only a small number of submitters contribute, to reduce potential misuse of the guidance.

### Description
- Inserted an amber-highlighted hint block into `data-use-terms.mdx` under the "Examples of what would be considered appropriate use of All Data" section that warns about the small number of submitters for Andes Virus [Hantavirus].

### Testing
- Built the website locally (`yarn build`) and reviewed the MDX rendering for the updated page, and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01caf73fd8832581898219b6db2a5e)

🚀 Preview: https://preview-codex-add-hint-box-to-using-all-data-section.pathoplexus.org