### PR TITLE
[codex] Update ANDV Nextclade datasets

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2172,15 +2172,15 @@ organisms:
         - name: "Nextclade (L)"
           category: "Nextclade"
           maxNumberOfRecommendedEntries: 3000
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:L+rich|fasta]}}&dataset-name=andv/L&dataset-server=https://pathoplexus.github.io/reference_store/andv/nextclade_data"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:L+rich|fasta]}}&dataset-name=nextstrain/orthohantavirus/andv/l"
         - name: "Nextclade (M)"
           category: "Nextclade"
           maxNumberOfRecommendedEntries: 5000
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:M+rich|fasta]}}&dataset-name=andv/M&dataset-server=https://pathoplexus.github.io/reference_store/andv/nextclade_data"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:M+rich|fasta]}}&dataset-name=nextstrain/orthohantavirus/andv/m"
         - name: "Nextclade (S)"
           category: "Nextclade"
           maxNumberOfRecommendedEntries: 10000
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:S+rich|fasta]}}&dataset-name=andv/S&dataset-server=https://pathoplexus.github.io/reference_store/andv/nextclade_data"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences:S+rich|fasta]}}&dataset-name=nextstrain/orthohantavirus/andv/s"
         - name: "Country map"
           category: "Other"
           maxNumberOfRecommendedEntries: 45000
@@ -2203,29 +2203,31 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 1
+          - 2
         configFile:
           <<: *preprocessingConfigFile
           create_embl_file: false
           taxon_id: 1980456
           scientific_name: "Andes Virus"
           molecule_type: "genomic RNA"
-          nextclade_dataset_server: "https://pathoplexus.github.io/reference_store/andv/nextclade_data"
           segments:
             - name: L
               references:
                 - name: singleReference
-                  nextclade_dataset_name: andv/L
+                  nextclade_dataset_name: nextstrain/orthohantavirus/andv/l
+                  nextclade_dataset_tag: "2026-05-11--18-59-50Z"
                   genes: [RdRp]
             - name: M
               references:
                 - name: singleReference
-                  nextclade_dataset_name: andv/M
-                  genes: [GPC]
+                  nextclade_dataset_name: nextstrain/orthohantavirus/andv/m
+                  nextclade_dataset_tag: "2026-05-11--18-59-50Z"
+                  genes: [GPC, Gn, Gc]
             - name: S
               references:
                 - name: singleReference
-                  nextclade_dataset_name: andv/S
+                  nextclade_dataset_name: nextstrain/orthohantavirus/andv/s
+                  nextclade_dataset_tag: "2026-05-11--18-59-50Z"
                   genes: ["N", NSs]
     ingest:
       <<: *ingest


### PR DESCRIPTION
## Summary

Update Andes virus Nextclade configuration to use the official Nextclade dataset server paths:

- `nextstrain/orthohantavirus/andv/l`
- `nextstrain/orthohantavirus/andv/m`
- `nextstrain/orthohantavirus/andv/s`

This removes the custom `pathoplexus.github.io/reference_store/andv/nextclade_data` dataset server from the ANDV link-outs and preprocessing config.

## Annotation changes checked

The current official M segment dataset tag (`2026-05-11--18-59-50Z`) adds the requested annotation shape: `GPC` covers the full precursor, and `Gn`/`Gc` cover the split glycoproteins. The Loculus M-segment gene list is updated from `GPC` to `GPC, Gn, Gc`.

L and S keep the expected gene names: `RdRp`, `N`, and `NSs`.

## Preprocessing

Bumped the ANDV preprocessing version from `1` to `2` and pinned all three official datasets to `2026-05-11--18-59-50Z`.

## Validation

- Verified the official Nextclade v3 index contains the new ANDV paths and tag
- Compared old custom and current official GFF annotations for ANDV L/M/S
- `ruby -e 'require "yaml"; YAML.load_file("loculus_values/values.yaml", aliases: true)'`
- `git diff --check`
- `helm template` for `demo`, `main`, `production`, and `staging` overlays

🚀 Preview: Add `preview` label to enable