### PR TITLE
fix(config): change hostTaxonId to type: string to match Loculus changes

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -75,18 +75,25 @@ zstdCompressionLevel: 20
 lineageSystemDefinitions:
   mpox:
     18: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2025-09-09--12-13-13Z/lineages.yaml
+    19: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2025-09-09--12-13-13Z/lineages.yaml
   rsv-a:
     19: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
+    20: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
   rsv-b:
     20: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-b/2025-08-25--09-00-35Z/lineages.yaml
+    21: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-b/2025-08-25--09-00-35Z/lineages.yaml
   hmpv:
     21: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/hmpv/2025-09-09--12-13-13Z/lineages.yaml
+    22: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/hmpv/2025-09-09--12-13-13Z/lineages.yaml
   cchfS:
     21: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/cchf/S/2025-09-24--07-29-03Z/lineages.yaml
+    22: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/cchf/S/2025-09-24--07-29-03Z/lineages.yaml
   marburg:
     22: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/marburg/2025-09-09--12-13-13Z/lineages.yaml
+    23: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/marburg/2025-09-09--12-13-13Z/lineages.yaml
   dengue:
-   28: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/dengue/all/2025-09-09--12-13-13Z/lineages.yaml
+    28: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/dengue/all/2025-09-09--12-13-13Z/lineages.yaml
+    29: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/dengue/all/2025-09-09--12-13-13Z/lineages.yaml
 defaultOrganismConfig: &defaultOrganismConfig
   schema: &schema
     submissionDataTypes: &defaultSubmissionDataTypes
@@ -1679,6 +1686,19 @@ organisms:
                   nextclade_dataset_name: nextstrain/orthoebolavirus/ebov
                   nextclade_dataset_tag: "2025-09-24--07-29-03Z"
                   genes: [NP, VP35, VP40, GP, sGP, ssGP, VP30, VP24, L]
+      - <<: *preprocessing
+        replicas: 1
+        version:
+          - 28
+        configFile:
+          <<: *preprocessingConfigFile
+          segments:
+            - name: main
+              references:
+                - name: "singleReference"
+                  nextclade_dataset_name: nextstrain/orthoebolavirus/ebov
+                  nextclade_dataset_tag: "2025-09-24--07-29-03Z"
+                  genes: [NP, VP35, VP40, GP, sGP, ssGP, VP30, VP24, L]
     enaDeposition:
       singleReference:
         configFile:
@@ -1733,6 +1753,18 @@ organisms:
       - <<: *preprocessing
         version:
           - 24
+        configFile:
+          <<: *preprocessingConfigFile
+          segments:
+            - name: main
+              references:
+                - name: "singleReference"
+                  nextclade_dataset_name: nextstrain/orthoebolavirus/sudv
+                  nextclade_dataset_tag: "2025-09-24--07-29-03Z"
+                  genes: [NP, VP35, VP40, GP, sGP, ssGP, VP30, VP24, L]
+      - <<: *preprocessing
+        version:
+          - 25
         configFile:
           <<: *preprocessingConfigFile
           segments:
@@ -1798,6 +1830,18 @@ organisms:
       - <<: *preprocessing
         version:
           - 1
+        configFile:
+          <<: *preprocessingConfigFile
+          segments:
+            - name: main
+              references:
+                - name: "singleReference"
+                  nextclade_dataset_name: nextstrain/orthoebolavirus/bdbv
+                  nextclade_dataset_tag: "2026-05-15--16-16-45Z"
+                  genes: [NP, VP35, VP40, GP, GP_003, VP30, VP24, L]
+      - <<: *preprocessing
+        version:
+          - 2
         configFile:
           <<: *preprocessingConfigFile
           segments:
@@ -1970,6 +2014,34 @@ organisms:
       - <<: *preprocessing
         version:
           - 28
+        replicas: 1
+        configFile:
+          <<: *preprocessingConfigFile
+          segment_classification_method: "minimizer"
+          create_embl_file: false
+          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/dengue/minimizer.json"
+          segments:
+            - name: main
+              references:
+                - name: DENV-1
+                  nextclade_dataset_name: community/v-gen-lab/dengue/denv1
+                  nextclade_dataset_tag: 2025-09-09--12-13-13Z
+                  genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
+                - name: DENV-2
+                  nextclade_dataset_name: community/v-gen-lab/dengue/denv2
+                  nextclade_dataset_tag: 2025-09-09--12-13-13Z
+                  genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
+                - name: DENV-3
+                  nextclade_dataset_name: community/v-gen-lab/dengue/denv3
+                  nextclade_dataset_tag: 2025-09-09--12-13-13Z
+                  genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
+                - name: DENV-4
+                  nextclade_dataset_name: community/v-gen-lab/dengue/denv4
+                  nextclade_dataset_tag: 2025-09-09--12-13-13Z
+                  genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
+      - <<: *preprocessing
+        version:
+          - 29
         replicas: 1
         configFile:
           <<: *preprocessingConfigFile
@@ -2191,6 +2263,18 @@ organisms:
                 nextclade_dataset_name: nextstrain/wnv/all-lineages
                 nextclade_dataset_tag: "2026-03-04--12-40-26Z"
                 genes: [capsid, prM, env, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
+      - <<: *preprocessing
+        version:
+          - 26
+        configFile:
+          <<: *preprocessingConfigFile
+          segments:
+            - name: main
+              references:
+              - name: singleReference
+                nextclade_dataset_name: nextstrain/wnv/all-lineages
+                nextclade_dataset_tag: "2026-03-04--12-40-26Z"
+                genes: [capsid, prM, env, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
     ingest:
       <<: *ingest
       configFile:
@@ -2278,6 +2362,32 @@ organisms:
       - <<: *preprocessing
         version:
           - 1
+        configFile:
+          <<: *preprocessingConfigFile
+          create_embl_file: false
+          taxon_id: 1980456
+          scientific_name: "Andes Virus"
+          molecule_type: "genomic RNA"
+          nextclade_dataset_server: "https://pathoplexus.github.io/reference_store/andv/nextclade_data"
+          segments:
+            - name: L
+              references:
+                - name: singleReference
+                  nextclade_dataset_name: andv/L
+                  genes: [RdRp]
+            - name: M
+              references:
+                - name: singleReference
+                  nextclade_dataset_name: andv/M
+                  genes: [GPC]
+            - name: S
+              references:
+                - name: singleReference
+                  nextclade_dataset_name: andv/S
+                  genes: ["N", NSs]
+      - <<: *preprocessing
+        version:
+          - 2
         configFile:
           <<: *preprocessingConfigFile
           create_embl_file: false
@@ -2418,6 +2528,29 @@ organisms:
       - <<: *preprocessing
         version:
           - 21
+        configFile:
+          <<: *preprocessingConfigFile
+          log_level: DEBUG
+          segments:
+            - name: L
+              references:
+              - name: singleReference
+                nextclade_dataset_name: community/pathoplexus/cchfv/L
+                genes: [RdRp]
+            - name: M
+              references:
+              - name: singleReference
+                nextclade_dataset_name: community/pathoplexus/cchfv/M
+                genes: [GPC]
+            - name: S
+              references:
+              - name: singleReference
+                nextclade_dataset_name: community/pathoplexus/cchfv/S
+                genes: [NP]
+          segment_classification_method: "align"
+      - <<: *preprocessing
+        version:
+          - 22
         configFile:
           <<: *preprocessingConfigFile
           log_level: DEBUG
@@ -2766,15 +2899,15 @@ organisms:
                   - OPG208
                   - OPG209
                   - OPG210
-      # - <<: *mpoxPreprocessing
-      #   replicas: 3
-      #   version:
-      #     - 18
-      #   configFile:
-      #     <<: *preprocessingConfigFile
-      #     batch_size: 10
-      #     segments:
-      #       - <<: *mpoxDataset
+      - <<: *mpoxPreprocessing
+        replicas: 3
+        version:
+          - 19
+        configFile:
+          <<: *preprocessingConfigFile
+          batch_size: 10
+          segments:
+            - <<: *mpoxDataset
     ingest:
       <<: *ingest
       configFile:
@@ -3221,6 +3354,23 @@ organisms:
                   - rsv-a
           require_nextclade_sort_match: true
           minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
+      - <<: *preprocessing
+        version:
+          - 20
+        replicas: 1
+        configFile:
+          <<: *preprocessingConfigFile
+          segments:
+            - name: main
+              references:
+              - name: singleReference
+                genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
+                nextclade_dataset_name: "nextstrain/rsv/a/EPI_ISL_412866"
+                nextclade_dataset_tag: "2025-08-25--09-00-35Z"
+                accepted_dataset_matches: 
+                  - rsv-a
+          require_nextclade_sort_match: true
+          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
     ingest:
       <<: *ingest
       configFile:
@@ -3344,6 +3494,23 @@ organisms:
                 genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
           require_nextclade_sort_match: true
           minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
+      - <<: *preprocessing
+        version:
+          - 21
+        replicas: 1
+        configFile:
+          <<: *preprocessingConfigFile
+          segments:
+            - name: main
+              references:
+              - name: singleReference
+                nextclade_dataset_name: "nextstrain/rsv/b/EPI_ISL_1653999"
+                nextclade_dataset_tag: "2025-08-25--09-00-35Z"
+                accepted_dataset_matches:
+                  - rsv-b
+                genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
+          require_nextclade_sort_match: true
+          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
     ingest:
       <<: *ingest
       configFile:
@@ -3443,6 +3610,19 @@ organisms:
         replicas: 1
         version:
           - 21
+        configFile:
+          <<: *preprocessingConfigFile
+          segments:
+            - name: main
+              references:
+              - name: singleReference
+                nextclade_dataset_name: "nextstrain/hmpv/all-clades/NC_039199"
+                nextclade_dataset_tag: "2025-04-25--12-24-24Z"
+                genes: [ "F", "G", "L", "M", "N", "M2-1", "M2-2", "P", "SH" ]
+      - <<: *preprocessing
+        replicas: 1
+        version:
+          - 22
         configFile:
           <<: *preprocessingConfigFile
           segments:
@@ -3556,6 +3736,19 @@ organisms:
                 nextclade_dataset_name: "nextstrain/measles/genome/WHO-2012"
                 nextclade_dataset_tag: "2025-08-11--19-06-01Z"
                 genes: [ "C", "F", "H", "L", "M", "N", "P", "V" ]
+      - <<: *preprocessing
+        version:
+          - 26
+        replicas: 1
+        configFile:
+          <<: *preprocessingConfigFile
+          segments:
+            - name: main
+              references:
+              - name: singleReference
+                nextclade_dataset_name: "nextstrain/measles/genome/WHO-2012"
+                nextclade_dataset_tag: "2025-08-11--19-06-01Z"
+                genes: [ "C", "F", "H", "L", "M", "N", "P", "V" ]
     ingest:
       <<: *ingest
       configFile:
@@ -3642,6 +3835,19 @@ organisms:
       - <<: *preprocessing
         version:
           - 22
+        replicas: 1
+        configFile:
+          <<: *preprocessingConfigFile
+          segments:
+            - name: main
+              references:
+              - name: singleReference
+                nextclade_dataset_name: "community/genspectrum/marburg/HK1980/all-lineages"
+                nextclade_dataset_tag: "2025-09-09--12-13-13Z"
+                genes: [GP, L, NP, VP24, VP30, VP35, VP40]
+      - <<: *preprocessing
+        version:
+          - 23
         replicas: 1
         configFile:
           <<: *preprocessingConfigFile
@@ -3790,6 +3996,18 @@ organisms:
                 nextclade_dataset_name: community/pathoplexus/yellow-fever-virus
                 genes: ["C", "prM", "M", "E", "NS1", "NS2a", "NS2b", "NS3", "NS4a", "2K", "NS4b", "RdRPol"]
           nextclade_dataset_server: https://raw.githubusercontent.com/maverbiest/nextclade_data/yellow-fever-virus/data_output
+      - <<: *preprocessing
+        version:
+          - 28
+        configFile:
+          <<: *preprocessingConfigFile
+          segments:
+            - name: main
+              references:
+              - name: singleReference 
+                nextclade_dataset_name: community/pathoplexus/yellow-fever-virus
+                genes: ["C", "prM", "M", "E", "NS1", "NS2a", "NS2b", "NS3", "NS4a", "2K", "NS4b", "RdRPol"]
+          nextclade_dataset_server: https://raw.githubusercontent.com/maverbiest/nextclade_data/yellow-fever-virus/data_output
     ingest:
       <<: *ingest
       configFile:
@@ -3844,7 +4062,7 @@ defaultResources:
     cpu: "1000m"
 
 taxonomyService:
-  dbVersion: "ncbi_taxonomy_latest"
+  dbVersion: "ncbi_taxonomy_2026-05-01"
   taxonomyDbPath: "/data/taxonomy.sqlite" # this is where the init container mounts the database
 
 resources:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1943,6 +1943,8 @@ organisms:
       metadataAdd:
         - <<: *hostTaxonIdConfig
           required: true
+          hierarchicalFilter: *taxonomy_service_url
+          hierarchicalSearchLabel: "include subtaxa"
         - name: lineage
           displayName: Lineage
           definition: "Clade label assigned by Nextclade, for views on the datasets see https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/community/v-gen-lab/dengue/denv1/2025-09-09--12-13-13Z/tree.json for DENV-1, https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/community/v-gen-lab/dengue/denv2/2025-09-09--12-13-13Z/tree.json for DENV-2, https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/community/v-gen-lab/dengue/denv3/2025-09-09--12-13-13Z/tree.json for DENV-3 and https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/community/v-gen-lab/dengue/denv4/2025-09-09--12-13-13Z/tree.json for DENV-4."
@@ -2223,6 +2225,9 @@ organisms:
           maxNumberOfRecommendedEntries: 2500
           url: "https://www.taxonium.org/build?mode=no_genbank&startingTreeUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/West_Nile_virus_385_99/optimized.pb.gz}}&refGbffUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/West_Nile_virus_385_99/treetime_rerooted_NC_009942.1.gbff}}&refFastaUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/West_Nile_virus_385_99/treetime_rerooted_NC_009942.1.fa}}&originalMetadataUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/West_Nile_virus_385_99/metadata.tsv.gz}}&fastaUrl={{[unalignedNucleotideSequences|fasta]}}&metadataUrl={{[metadata]}}&organism={{West Nile virus}}"
       metadataAdd:
+        - <<: *hostTaxonIdConfig
+          hierarchicalFilter: *taxonomy_service_url
+          hierarchicalSearchLabel: "include subtaxa"
         - name: lineage
           displayName: Lineage
           definition: "Clade label assigned by Nextclade, see https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/nextstrain/wnv/all-lineages/2026-03-04--12-40-26Z/tree.json for a view of the Nextclade dataset."
@@ -3924,6 +3929,8 @@ organisms:
       metadataAdd:
         - <<: *hostTaxonIdConfig
           required: true
+          hierarchicalFilter: *taxonomy_service_url
+          hierarchicalSearchLabel: "include subtaxa"
         - name: clade
           displayName: Clade
           definition: "Clade label assigned by Nextclade, see https://nextstrain.org/fetch/raw.githubusercontent.com/maverbiest/nextclade_data/yellow-fever-virus/data_output/community/pathoplexus/yellow-fever-virus/unreleased/tree.json for a view of the Nextclade dataset."

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -86,7 +86,7 @@ lineageSystemDefinitions:
   marburg:
     22: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/marburg/2025-09-09--12-13-13Z/lineages.yaml
   dengue:
-   28: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/dengue/all/2025-09-09--12-13-13Z/lineages.yaml
+    28: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/dengue/all/2025-09-09--12-13-13Z/lineages.yaml
 defaultOrganismConfig: &defaultOrganismConfig
   schema: &schema
     submissionDataTypes: &defaultSubmissionDataTypes
@@ -3851,7 +3851,7 @@ defaultResources:
     cpu: "1000m"
 
 taxonomyService:
-  dbVersion: "ncbi_taxonomy_latest"
+  dbVersion: "ncbi_taxonomy_2026-05-01"
   taxonomyDbPath: "/data/taxonomy.sqlite" # this is where the init container mounts the database
 
 resources:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1312,8 +1312,6 @@ defaultOrganismConfig: &defaultOrganismConfig
         name: hostTaxonId
         displayName: Host taxon ID
         type: string
-        hierarchicalFilter: *taxonomy_service_url
-        hierarchicalSearchLabel: "include subtaxa"
         autocomplete: true
         customDisplay:
           type: hostSpecies
@@ -1899,8 +1897,6 @@ organisms:
       metadataAdd:
         - <<: *hostTaxonIdConfig
           required: true
-          hierarchicalFilter: *taxonomy_service_url
-          hierarchicalSearchLabel: "include subtaxa"
         - name: lineage
           displayName: Lineage
           definition: "Clade label assigned by Nextclade, for views on the datasets see https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/community/v-gen-lab/dengue/denv1/2025-09-09--12-13-13Z/tree.json for DENV-1, https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/community/v-gen-lab/dengue/denv2/2025-09-09--12-13-13Z/tree.json for DENV-2, https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/community/v-gen-lab/dengue/denv3/2025-09-09--12-13-13Z/tree.json for DENV-3 and https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/community/v-gen-lab/dengue/denv4/2025-09-09--12-13-13Z/tree.json for DENV-4."
@@ -2153,9 +2149,6 @@ organisms:
           maxNumberOfRecommendedEntries: 2500
           url: "https://www.taxonium.org/build?mode=no_genbank&startingTreeUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/West_Nile_virus_385_99/optimized.pb.gz}}&refGbffUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/West_Nile_virus_385_99/treetime_rerooted_NC_009942.1.gbff}}&refFastaUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/West_Nile_virus_385_99/treetime_rerooted_NC_009942.1.fa}}&originalMetadataUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/West_Nile_virus_385_99/metadata.tsv.gz}}&fastaUrl={{[unalignedNucleotideSequences|fasta]}}&metadataUrl={{[metadata]}}&organism={{West Nile virus}}"
       metadataAdd:
-        - <<: *hostTaxonIdConfig
-          hierarchicalFilter: *taxonomy_service_url
-          hierarchicalSearchLabel: "include subtaxa"
         - name: lineage
           displayName: Lineage
           definition: "Clade label assigned by Nextclade, see https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/nextstrain/wnv/all-lineages/2026-03-04--12-40-26Z/tree.json for a view of the Nextclade dataset."
@@ -3723,8 +3716,6 @@ organisms:
       metadataAdd:
         - <<: *hostTaxonIdConfig
           required: true
-          hierarchicalFilter: *taxonomy_service_url
-          hierarchicalSearchLabel: "include subtaxa"
         - name: clade
           displayName: Clade
           definition: "Clade label assigned by Nextclade, see https://nextstrain.org/fetch/raw.githubusercontent.com/maverbiest/nextclade_data/yellow-fever-virus/data_output/community/pathoplexus/yellow-fever-virus/unreleased/tree.json for a view of the Nextclade dataset."

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -75,25 +75,18 @@ zstdCompressionLevel: 20
 lineageSystemDefinitions:
   mpox:
     18: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2025-09-09--12-13-13Z/lineages.yaml
-    19: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2025-09-09--12-13-13Z/lineages.yaml
   rsv-a:
     19: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
-    20: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
   rsv-b:
     20: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-b/2025-08-25--09-00-35Z/lineages.yaml
-    21: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-b/2025-08-25--09-00-35Z/lineages.yaml
   hmpv:
     21: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/hmpv/2025-09-09--12-13-13Z/lineages.yaml
-    22: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/hmpv/2025-09-09--12-13-13Z/lineages.yaml
   cchfS:
     21: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/cchf/S/2025-09-24--07-29-03Z/lineages.yaml
-    22: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/cchf/S/2025-09-24--07-29-03Z/lineages.yaml
   marburg:
     22: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/marburg/2025-09-09--12-13-13Z/lineages.yaml
-    23: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/marburg/2025-09-09--12-13-13Z/lineages.yaml
   dengue:
-    28: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/dengue/all/2025-09-09--12-13-13Z/lineages.yaml
-    29: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/dengue/all/2025-09-09--12-13-13Z/lineages.yaml
+   28: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/dengue/all/2025-09-09--12-13-13Z/lineages.yaml
 defaultOrganismConfig: &defaultOrganismConfig
   schema: &schema
     submissionDataTypes: &defaultSubmissionDataTypes
@@ -1686,19 +1679,6 @@ organisms:
                   nextclade_dataset_name: nextstrain/orthoebolavirus/ebov
                   nextclade_dataset_tag: "2025-09-24--07-29-03Z"
                   genes: [NP, VP35, VP40, GP, sGP, ssGP, VP30, VP24, L]
-      - <<: *preprocessing
-        replicas: 1
-        version:
-          - 28
-        configFile:
-          <<: *preprocessingConfigFile
-          segments:
-            - name: main
-              references:
-                - name: "singleReference"
-                  nextclade_dataset_name: nextstrain/orthoebolavirus/ebov
-                  nextclade_dataset_tag: "2025-09-24--07-29-03Z"
-                  genes: [NP, VP35, VP40, GP, sGP, ssGP, VP30, VP24, L]
     enaDeposition:
       singleReference:
         configFile:
@@ -1753,18 +1733,6 @@ organisms:
       - <<: *preprocessing
         version:
           - 24
-        configFile:
-          <<: *preprocessingConfigFile
-          segments:
-            - name: main
-              references:
-                - name: "singleReference"
-                  nextclade_dataset_name: nextstrain/orthoebolavirus/sudv
-                  nextclade_dataset_tag: "2025-09-24--07-29-03Z"
-                  genes: [NP, VP35, VP40, GP, sGP, ssGP, VP30, VP24, L]
-      - <<: *preprocessing
-        version:
-          - 25
         configFile:
           <<: *preprocessingConfigFile
           segments:
@@ -1830,18 +1798,6 @@ organisms:
       - <<: *preprocessing
         version:
           - 1
-        configFile:
-          <<: *preprocessingConfigFile
-          segments:
-            - name: main
-              references:
-                - name: "singleReference"
-                  nextclade_dataset_name: nextstrain/orthoebolavirus/bdbv
-                  nextclade_dataset_tag: "2026-05-15--16-16-45Z"
-                  genes: [NP, VP35, VP40, GP, GP_003, VP30, VP24, L]
-      - <<: *preprocessing
-        version:
-          - 2
         configFile:
           <<: *preprocessingConfigFile
           segments:
@@ -2016,34 +1972,6 @@ organisms:
       - <<: *preprocessing
         version:
           - 28
-        replicas: 1
-        configFile:
-          <<: *preprocessingConfigFile
-          segment_classification_method: "minimizer"
-          create_embl_file: false
-          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/dengue/minimizer.json"
-          segments:
-            - name: main
-              references:
-                - name: DENV-1
-                  nextclade_dataset_name: community/v-gen-lab/dengue/denv1
-                  nextclade_dataset_tag: 2025-09-09--12-13-13Z
-                  genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
-                - name: DENV-2
-                  nextclade_dataset_name: community/v-gen-lab/dengue/denv2
-                  nextclade_dataset_tag: 2025-09-09--12-13-13Z
-                  genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
-                - name: DENV-3
-                  nextclade_dataset_name: community/v-gen-lab/dengue/denv3
-                  nextclade_dataset_tag: 2025-09-09--12-13-13Z
-                  genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
-                - name: DENV-4
-                  nextclade_dataset_name: community/v-gen-lab/dengue/denv4
-                  nextclade_dataset_tag: 2025-09-09--12-13-13Z
-                  genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
-      - <<: *preprocessing
-        version:
-          - 29
         replicas: 1
         configFile:
           <<: *preprocessingConfigFile
@@ -2268,18 +2196,6 @@ organisms:
                 nextclade_dataset_name: nextstrain/wnv/all-lineages
                 nextclade_dataset_tag: "2026-03-04--12-40-26Z"
                 genes: [capsid, prM, env, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
-      - <<: *preprocessing
-        version:
-          - 26
-        configFile:
-          <<: *preprocessingConfigFile
-          segments:
-            - name: main
-              references:
-              - name: singleReference
-                nextclade_dataset_name: nextstrain/wnv/all-lineages
-                nextclade_dataset_tag: "2026-03-04--12-40-26Z"
-                genes: [capsid, prM, env, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
     ingest:
       <<: *ingest
       configFile:
@@ -2367,32 +2283,6 @@ organisms:
       - <<: *preprocessing
         version:
           - 1
-        configFile:
-          <<: *preprocessingConfigFile
-          create_embl_file: false
-          taxon_id: 1980456
-          scientific_name: "Andes Virus"
-          molecule_type: "genomic RNA"
-          nextclade_dataset_server: "https://pathoplexus.github.io/reference_store/andv/nextclade_data"
-          segments:
-            - name: L
-              references:
-                - name: singleReference
-                  nextclade_dataset_name: andv/L
-                  genes: [RdRp]
-            - name: M
-              references:
-                - name: singleReference
-                  nextclade_dataset_name: andv/M
-                  genes: [GPC]
-            - name: S
-              references:
-                - name: singleReference
-                  nextclade_dataset_name: andv/S
-                  genes: ["N", NSs]
-      - <<: *preprocessing
-        version:
-          - 2
         configFile:
           <<: *preprocessingConfigFile
           create_embl_file: false
@@ -2533,29 +2423,6 @@ organisms:
       - <<: *preprocessing
         version:
           - 21
-        configFile:
-          <<: *preprocessingConfigFile
-          log_level: DEBUG
-          segments:
-            - name: L
-              references:
-              - name: singleReference
-                nextclade_dataset_name: community/pathoplexus/cchfv/L
-                genes: [RdRp]
-            - name: M
-              references:
-              - name: singleReference
-                nextclade_dataset_name: community/pathoplexus/cchfv/M
-                genes: [GPC]
-            - name: S
-              references:
-              - name: singleReference
-                nextclade_dataset_name: community/pathoplexus/cchfv/S
-                genes: [NP]
-          segment_classification_method: "align"
-      - <<: *preprocessing
-        version:
-          - 22
         configFile:
           <<: *preprocessingConfigFile
           log_level: DEBUG
@@ -2904,15 +2771,15 @@ organisms:
                   - OPG208
                   - OPG209
                   - OPG210
-      - <<: *mpoxPreprocessing
-        replicas: 3
-        version:
-          - 19
-        configFile:
-          <<: *preprocessingConfigFile
-          batch_size: 10
-          segments:
-            - <<: *mpoxDataset
+      # - <<: *mpoxPreprocessing
+      #   replicas: 3
+      #   version:
+      #     - 18
+      #   configFile:
+      #     <<: *preprocessingConfigFile
+      #     batch_size: 10
+      #     segments:
+      #       - <<: *mpoxDataset
     ingest:
       <<: *ingest
       configFile:
@@ -3359,23 +3226,6 @@ organisms:
                   - rsv-a
           require_nextclade_sort_match: true
           minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
-      - <<: *preprocessing
-        version:
-          - 20
-        replicas: 1
-        configFile:
-          <<: *preprocessingConfigFile
-          segments:
-            - name: main
-              references:
-              - name: singleReference
-                genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
-                nextclade_dataset_name: "nextstrain/rsv/a/EPI_ISL_412866"
-                nextclade_dataset_tag: "2025-08-25--09-00-35Z"
-                accepted_dataset_matches: 
-                  - rsv-a
-          require_nextclade_sort_match: true
-          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
     ingest:
       <<: *ingest
       configFile:
@@ -3499,23 +3349,6 @@ organisms:
                 genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
           require_nextclade_sort_match: true
           minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
-      - <<: *preprocessing
-        version:
-          - 21
-        replicas: 1
-        configFile:
-          <<: *preprocessingConfigFile
-          segments:
-            - name: main
-              references:
-              - name: singleReference
-                nextclade_dataset_name: "nextstrain/rsv/b/EPI_ISL_1653999"
-                nextclade_dataset_tag: "2025-08-25--09-00-35Z"
-                accepted_dataset_matches:
-                  - rsv-b
-                genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
-          require_nextclade_sort_match: true
-          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
     ingest:
       <<: *ingest
       configFile:
@@ -3615,19 +3448,6 @@ organisms:
         replicas: 1
         version:
           - 21
-        configFile:
-          <<: *preprocessingConfigFile
-          segments:
-            - name: main
-              references:
-              - name: singleReference
-                nextclade_dataset_name: "nextstrain/hmpv/all-clades/NC_039199"
-                nextclade_dataset_tag: "2025-04-25--12-24-24Z"
-                genes: [ "F", "G", "L", "M", "N", "M2-1", "M2-2", "P", "SH" ]
-      - <<: *preprocessing
-        replicas: 1
-        version:
-          - 22
         configFile:
           <<: *preprocessingConfigFile
           segments:
@@ -3741,19 +3561,6 @@ organisms:
                 nextclade_dataset_name: "nextstrain/measles/genome/WHO-2012"
                 nextclade_dataset_tag: "2025-08-11--19-06-01Z"
                 genes: [ "C", "F", "H", "L", "M", "N", "P", "V" ]
-      - <<: *preprocessing
-        version:
-          - 26
-        replicas: 1
-        configFile:
-          <<: *preprocessingConfigFile
-          segments:
-            - name: main
-              references:
-              - name: singleReference
-                nextclade_dataset_name: "nextstrain/measles/genome/WHO-2012"
-                nextclade_dataset_tag: "2025-08-11--19-06-01Z"
-                genes: [ "C", "F", "H", "L", "M", "N", "P", "V" ]
     ingest:
       <<: *ingest
       configFile:
@@ -3840,19 +3647,6 @@ organisms:
       - <<: *preprocessing
         version:
           - 22
-        replicas: 1
-        configFile:
-          <<: *preprocessingConfigFile
-          segments:
-            - name: main
-              references:
-              - name: singleReference
-                nextclade_dataset_name: "community/genspectrum/marburg/HK1980/all-lineages"
-                nextclade_dataset_tag: "2025-09-09--12-13-13Z"
-                genes: [GP, L, NP, VP24, VP30, VP35, VP40]
-      - <<: *preprocessing
-        version:
-          - 23
         replicas: 1
         configFile:
           <<: *preprocessingConfigFile
@@ -4003,18 +3797,6 @@ organisms:
                 nextclade_dataset_name: community/pathoplexus/yellow-fever-virus
                 genes: ["C", "prM", "M", "E", "NS1", "NS2a", "NS2b", "NS3", "NS4a", "2K", "NS4b", "RdRPol"]
           nextclade_dataset_server: https://raw.githubusercontent.com/maverbiest/nextclade_data/yellow-fever-virus/data_output
-      - <<: *preprocessing
-        version:
-          - 28
-        configFile:
-          <<: *preprocessingConfigFile
-          segments:
-            - name: main
-              references:
-              - name: singleReference 
-                nextclade_dataset_name: community/pathoplexus/yellow-fever-virus
-                genes: ["C", "prM", "M", "E", "NS1", "NS2a", "NS2b", "NS3", "NS4a", "2K", "NS4b", "RdRPol"]
-          nextclade_dataset_server: https://raw.githubusercontent.com/maverbiest/nextclade_data/yellow-fever-virus/data_output
     ingest:
       <<: *ingest
       configFile:
@@ -4069,7 +3851,7 @@ defaultResources:
     cpu: "1000m"
 
 taxonomyService:
-  dbVersion: "ncbi_taxonomy_2026-05-01"
+  dbVersion: "ncbi_taxonomy_latest"
   taxonomyDbPath: "/data/taxonomy.sqlite" # this is where the init container mounts the database
 
 resources:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1287,7 +1287,7 @@ defaultOrganismConfig: &defaultOrganismConfig
             hostTaxonId: processed.hostTaxonId
             hostNameScientific: hostNameScientific
           args:
-            taxonomy_service_url: "http://loculus-taxonomy-service:5000"
+            taxonomy_service_url: &taxonomy_service_url "http://loculus-taxonomy-service:5000"
       - name: hostNameCommon
         displayName: Host name - common
         generateIndex: true
@@ -1307,11 +1307,13 @@ defaultOrganismConfig: &defaultOrganismConfig
           inputs:
             hostTaxonId: processed.hostTaxonId
           args:
-            taxonomy_service_url: "http://loculus-taxonomy-service:5000"
+            taxonomy_service_url: *taxonomy_service_url
       - &hostTaxonIdConfig
         name: hostTaxonId
         displayName: Host taxon ID
-        type: int
+        type: string
+        hierarchicalFilter: *taxonomy_service_url
+        hierarchicalSearchLabel: "include subtaxa"
         autocomplete: true
         customDisplay:
           type: hostSpecies
@@ -1331,7 +1333,7 @@ defaultOrganismConfig: &defaultOrganismConfig
             hostNameScientific: hostNameScientific
             hostTaxonId: hostTaxonId
           args:
-            taxonomy_service_url: "http://loculus-taxonomy-service:5000"
+            taxonomy_service_url: *taxonomy_service_url
       - name: isLabHost
         displayName: Is lab host
         autocomplete: true

--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 29e3fca6e5a0ae26e9635d5b909c3a9339ba65d3
+loculusVersion: 0b0b978b68cfd6f863403539cecab0f4450f52ec
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy

--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: a91b5cbff890e26833c859567f2b9bc51b9e93bc
+loculusVersion: f18200ed79b922d29a3903e7afb2b62ada78108b
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy

--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 0b0b978b68cfd6f863403539cecab0f4450f52ec
+loculusVersion: a91b5cbff890e26833c859567f2b9bc51b9e93bc
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
To be merged when we roll out https://github.com/loculus-project/loculus/pull/6487.

This PR changes the metadata field `hostTaxonId` from int to string and pins the taxonomy DB to a specific version to match breaking changes in the above PR. In addition to merging this config change, we will need to run an SQL command against the database to convert existing hostTaxonIds to strings in the sequence_entries_preprocessed_data table (see Loculus PR for SQL).

🚀 Preview: Add `preview` label to enable