### PR TITLE
feat(website): Separate Nextstrain external links for hanta segments

### DIFF
--- a/monorepo/website/src/components/ExternalTools/tools.ts
+++ b/monorepo/website/src/components/ExternalTools/tools.ts
@@ -24,14 +24,55 @@ export const tools: Tool[] = [
             'https://nextstrain.org/' +
             {
                 /* eslint-disable @typescript-eslint/naming-convention */
-                'andv': 'groups/hodcroftlab/andv/L',
                 'hmpv': 'hmpv/all/genome',
                 'mpox': 'mpox/all-clades',
                 'rsv-a': 'rsv/a/genome/6y',
                 'rsv-b': 'rsv/b/genome/6y',
                 /* eslint-enable @typescript-eslint/naming-convention */
             }[organism]!,
-        organisms: ['andv', 'hmpv', 'mpox', 'rsv-a', 'rsv-b'],
+        organisms: ['hmpv', 'mpox', 'rsv-a', 'rsv-b'],
+    },
+    {
+        name: 'Nextstrain segment L',
+        description:
+            'Nextstrain is an open-source project that visualizes the real-time evolution and geographic spread of pathogens using genomic sequencing data.',
+        image: '/images/external-tools/nextstrain.png',
+        url: (organism) =>
+            'https://nextstrain.org/' +
+            {
+                /* eslint-disable @typescript-eslint/naming-convention */
+                'andv': 'groups/hodcroftlab/andv/L',
+                /* eslint-enable @typescript-eslint/naming-convention */
+            }[organism]!,
+        organisms: ['andv'],
+    },
+    {
+        name: 'Nextstrain segment M',
+        description:
+            'Nextstrain is an open-source project that visualizes the real-time evolution and geographic spread of pathogens using genomic sequencing data.',
+        image: '/images/external-tools/nextstrain.png',
+        url: (organism) =>
+            'https://nextstrain.org/' +
+            {
+                /* eslint-disable @typescript-eslint/naming-convention */
+                'andv': 'groups/hodcroftlab/andv/M',
+                /* eslint-enable @typescript-eslint/naming-convention */
+            }[organism]!,
+        organisms: ['andv'],
+    },
+    {
+        name: 'Nextstrain segment S',
+        description:
+            'Nextstrain is an open-source project that visualizes the real-time evolution and geographic spread of pathogens using genomic sequencing data.',
+        image: '/images/external-tools/nextstrain.png',
+        url: (organism) =>
+            'https://nextstrain.org/' +
+            {
+                /* eslint-disable @typescript-eslint/naming-convention */
+                'andv': 'groups/hodcroftlab/andv/S',
+                /* eslint-enable @typescript-eslint/naming-convention */
+            }[organism]!,
+        organisms: ['andv'],
     },
     {
         name: 'Pathogen Sequence Counts and Maps',


### PR DESCRIPTION
This PR introduces a (very hacky) way of showing different external Nextrstrain links for the three hanta virus segments:

<img width="789" height="722" alt="grafik" src="https://github.com/user-attachments/assets/8df50c01-be51-4e30-bb0b-6dbc2ef7bc35" />


This is a temporary workaround since we're currently in a somewhat unique situation. Ideally, we should add implementation that allows us to do this more nicely, also for other segmented viruses etc.

🚀 Preview: https://preview-per-segment-ns-andv.pathoplexus.org