### PR TITLE
[codex] Update PPX ingest taxon IDs

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1927,7 +1927,7 @@ organisms:
     ingest:
       <<: *ingest
       configFile:
-        taxon_id: 12637
+        taxon_id: 3052464
     enaDeposition:
       DENV-1:
         configFile:
@@ -3696,7 +3696,7 @@ organisms:
       <<: *ingest
       configFile:
         <<: *defaultIngestConfigFile
-        taxon_id: 11089
+        taxon_id: 3046277
         log_level: DEBUG
     enaDeposition:
       singleReference:


### PR DESCRIPTION
## What changed

Updated the Pathoplexus INSDC ingest taxon IDs for:

- dengue: `12637` -> `3052464`
- yellow-fever: `11089` -> `3046277`

## Why

These use the current NCBI species-level parent nodes for the legacy/no-rank virus nodes, matching the intended ingest scope while keeping ENA deposition taxon IDs unchanged.

## Validation

- `python3` YAML parse of `loculus_values/values.yaml`
- `git diff --check`

🚀 Preview: https://preview-codex-update-ingest-taxids.pathoplexus.org