### PR TITLE
[codex] Add unaligned Ebola misc organism

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1770,6 +1770,100 @@ organisms:
               sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/VP24.fasta]]"
             - name: L
               sequence: "[[URL:https://corneliusroemer.github.io/seqs/artefacts/ebola-sudan/L.fasta]]"
+  ebola-misc:
+    <<: *defaultOrganismConfig
+    schema:
+      <<: *schema
+      organismName: "Ebola (other spp.)"
+      metadataAdd:
+        - name: length
+          type: int
+          header: "Sequence"
+          isSequenceFilter: true
+          noInput: true
+          rangeSearch: true
+          initiallyVisible: true
+          includeInDownloadsByDefault: true
+          displayName: Length
+          definition: The length of the sequence.
+          columnWidth: 84
+          order: 80
+          orderOnDetailsPage: 2700
+        - name: totalSnps
+          type: int
+          noInput: true
+          notSearchable: true
+          hideInSearchResultsTable: true
+          hideOnSequenceDetailsPage: true
+        - name: totalInsertedNucs
+          type: int
+          noInput: true
+          notSearchable: true
+          hideInSearchResultsTable: true
+          hideOnSequenceDetailsPage: true
+        - name: totalDeletedNucs
+          type: int
+          noInput: true
+          notSearchable: true
+          hideInSearchResultsTable: true
+          hideOnSequenceDetailsPage: true
+        - name: totalAmbiguousNucs
+          type: int
+          noInput: true
+          notSearchable: true
+          hideInSearchResultsTable: true
+          hideOnSequenceDetailsPage: true
+        - name: totalUnknownNucs
+          type: int
+          noInput: true
+          notSearchable: true
+          hideInSearchResultsTable: true
+          hideOnSequenceDetailsPage: true
+        - name: totalFrameShifts
+          type: int
+          noInput: true
+          notSearchable: true
+          hideInSearchResultsTable: true
+          hideOnSequenceDetailsPage: true
+        - name: frameShifts
+          noInput: true
+          notSearchable: true
+          hideInSearchResultsTable: true
+          hideOnSequenceDetailsPage: true
+        - name: completeness
+          type: float
+          noInput: true
+          notSearchable: true
+          hideInSearchResultsTable: true
+          hideOnSequenceDetailsPage: true
+        - name: totalStopCodons
+          type: int
+          noInput: true
+          notSearchable: true
+          hideInSearchResultsTable: true
+          hideOnSequenceDetailsPage: true
+        - name: stopCodons
+          noInput: true
+          notSearchable: true
+          hideInSearchResultsTable: true
+          hideOnSequenceDetailsPage: true
+    preprocessing:
+      - <<: *preprocessing
+        version:
+          - 1
+        configFile:
+          <<: *preprocessingConfigFile
+          segments:
+            - name: main
+              references:
+                - name: singleReference
+                  genes: []
+    ingest: {}
+    referenceGenomes:
+      - name: "main"
+        references:
+        - name: singleReference
+          sequence: "N"
   dengue:
     <<: *defaultOrganismConfig
     schema:


### PR DESCRIPTION
## Summary

Adds a new `ebola-misc` organism with display name `Ebola (other spp.)`.

The organism is configured as a single-segment, no-alignment organism by defining a `main` segment without a `nextclade_dataset_name`, following Loculus' implicit no-alignment pattern. Alignment-derived QC fields are hidden for this organism, while sequence `length` remains visible.

Automatic ingest is left disabled for this organism because the requested scope does not define a precise NCBI taxon for "other spp.".

## Validation

- Rendered the Loculus Helm chart with Pathoplexus values for `main`, `demo`, `staging`, and `production` overlays.
- Ran `git diff --check`.

🚀 Preview: Add `preview` label to enable