### PR TITLE
Add outbreak annotation to Bundibugyo dataset, reprocess with new Nextclade dataset

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1,3 +1,6 @@
+# REVERT DONT MERGE
+createTestAccounts: true
+# REVERT ABOVE
 preprocessingTimeout: 600
 getSubmissionListLimitSeconds: 3600
 robotsNoindexHeader: true

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1785,7 +1785,7 @@ organisms:
       linkOuts:
         - name: "Nextclade"
           maxNumberOfRecommendedEntries: 3000 # ebola is ~18.5kb
-          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences+rich|fasta]}}&dataset-name=nextstrain/orthoebolavirus/bdbv&dataset-tag=2026-05-15--16-16-45Z"
+          url: "https://clades.nextstrain.org/?input-fasta={{[unalignedNucleotideSequences+rich|fasta]}}&dataset-name=nextstrain/orthoebolavirus/bdbv"
         - name: "Sealion"
           maxNumberOfRecommendedEntries: 3000
           url: "https://artic-network.github.io/sealion/?fastaUrl={{[alignedNucleotideSequences+rich|fasta]}}"

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1,6 +1,3 @@
-# REVERT DONT MERGE
-createTestAccounts: true
-# REVERT ABOVE
 preprocessingTimeout: 600
 getSubmissionListLimitSeconds: 3600
 robotsNoindexHeader: true

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1620,7 +1620,7 @@ organisms:
       metadataAdd:
         - name: outbreak
           displayName: Outbreak
-          definition: "Clade label assigned by Nextclade, see https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/nextstrain/orthoebolavirus/ebov/2025-09-24--07-29-03Z/tree.json for a view of the Nextclade dataset."
+          definition: "Clade label assigned by Nextclade, see https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/nextstrain/orthoebolavirus/ebov/2025-09-24--07-29-03Z/tree.json for a view of the Nextclade tree."
           isSequenceFilter: true
           header: "Outbreak"
           includeInDownloadsByDefault: true
@@ -1792,6 +1792,32 @@ organisms:
         - name: "Country map"
           maxNumberOfRecommendedEntries: 45000
           url: "https://mapoplexus.genomium.org/?url={{[metadata]}}"
+      metadataAdd:
+        - name: outbreak
+          displayName: Outbreak
+          definition: "Outbreak assigned by Nextclade"
+          isSequenceFilter: true
+          header: "Outbreak"
+          includeInDownloadsByDefault: true
+          noInput: true
+          generateIndex: true
+          autocomplete: true
+          initiallyVisible: true
+          preprocessing:
+            inputs: {input: nextclade.outbreak}
+          order: 5
+          orderOnDetailsPage: 740
+      website:
+        <<: *website
+        tableColumns:
+          - sampleCollectionDate
+          - earliestReleaseDate
+          - authors
+          - authorAffiliations
+          - geoLocCountry
+          - geoLocAdmin1
+          - length
+          - outbreak
     preprocessing:
       - &ebolaBdbvPreprocessing
         <<: *preprocessing

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -86,7 +86,7 @@ lineageSystemDefinitions:
   marburg:
     22: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/marburg/2025-09-09--12-13-13Z/lineages.yaml
   dengue:
-   28: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/dengue/all/2025-09-09--12-13-13Z/lineages.yaml
+    28: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/dengue/all/2025-09-09--12-13-13Z/lineages.yaml
 defaultOrganismConfig: &defaultOrganismConfig
   schema: &schema
     submissionDataTypes: &defaultSubmissionDataTypes
@@ -1793,18 +1793,31 @@ organisms:
           maxNumberOfRecommendedEntries: 45000
           url: "https://mapoplexus.genomium.org/?url={{[metadata]}}"
     preprocessing:
-      - <<: *preprocessing
+      - &ebolaBdbvPreprocessing
+        <<: *preprocessing
         version:
           - 1
-        configFile:
+        configFile: &ebolaBdbvPreprocessingConfigFile
           <<: *preprocessingConfigFile
           segments:
-            - name: main
+            - &ebolaBdbvPreprocessingSegment
+              name: main
               references:
-                - name: "singleReference"
+                - &ebolaBdbvPreprocessingReference
+                  name: "singleReference"
                   nextclade_dataset_name: nextstrain/orthoebolavirus/bdbv
                   nextclade_dataset_tag: "2026-05-15--16-16-45Z"
                   genes: [NP, VP35, VP40, GP, GP_003, VP30, VP24, L]
+      - <<: *ebolaBdbvPreprocessing
+        version:
+          - 2
+        configFile:
+          <<: *ebolaBdbvPreprocessingConfigFile
+          segments:
+            - <<: *ebolaBdbvPreprocessingSegment
+              references:
+                - <<: *ebolaBdbvPreprocessingReference
+                  nextclade_dataset_tag: "2026-05-18--20-09-34Z"
     ingest:
       <<: *ingest
       configFile:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1804,7 +1804,7 @@ organisms:
           autocomplete: true
           initiallyVisible: true
           preprocessing:
-            inputs: {input: nextclade.outbreak}
+            inputs: {input: nextclade.customNodeAttributes.outbreak}
           order: 5
           orderOnDetailsPage: 740
       website:


### PR DESCRIPTION
- **Reprocess bdbv with new dataset version**
- **No need for exact dataset version in linkout to nextclade**
- **Lift outbreak annotation and display in table**


<img width="1682" height="395" alt="image" src="https://github.com/user-attachments/assets/0ec6b4ef-7805-4499-b2bc-03d99f5dcf16" />

🚀 Preview: https://preview-bdbv-outbreak.pathoplexus.org