### PR TITLE
Show YFV clade in search table and move Dengue/CCHF lineage/clade to left to canonical position

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2400,6 +2400,7 @@ organisms:
             inputs: {input: nextclade.clade}
           order: 5
           orderOnDetailsPage: 740
+          columnWidth: 60
       website:
         <<: *website
         tableColumns:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -3772,7 +3772,7 @@ organisms:
           - geoLocAdmin1
           - length
           - hostNameScientific
-          - lineage
+          - clade
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
     preprocessing:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2400,7 +2400,7 @@ organisms:
             inputs: {input: nextclade.clade}
           order: 5
           orderOnDetailsPage: 740
-          columnWidth: 60
+          columnWidth: 80
       website:
         <<: *website
         tableColumns:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1911,6 +1911,7 @@ organisms:
           preprocessing:
             inputs: {input: nextclade.clade}
           order: 5
+          columnWidth: 80
           orderOnDetailsPage: 740
         - name: specimenCollectorSampleId
           displayName: Isolate name

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1910,6 +1910,8 @@ organisms:
           includeInDownloadsByDefault: true
           preprocessing:
             inputs: {input: nextclade.clade}
+          order: 5
+          orderOnDetailsPage: 740
         - name: specimenCollectorSampleId
           displayName: Isolate name
           header: Sample details

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2396,6 +2396,8 @@ organisms:
           lineageSystem: cchfS
           preprocessing:
             inputs: {input: nextclade.clade}
+          order: 5
+          orderOnDetailsPage: 740
       website:
         <<: *website
         tableColumns:


### PR DESCRIPTION
- **Show YFV clade in default search table view**
- **Move CCHF segment S lineage to canonical lineage/clade position on left side in search table**
- **Move dengue lineage left in search table**

Fixing YFV table columns to include `clade`. It was `lineage` but that doesn't exist

Now all lineage/clade/outbreak columns across all organisms are immediately to the right of the accession column for uniform appearance.

<img width="1400" height="186" alt="image" src="https://github.com/user-attachments/assets/fccf0344-7757-4ee3-890f-b64986001ada" />

<img width="1588" height="182" alt="image" src="https://github.com/user-attachments/assets/b1a1a9c6-6e99-4f31-b8b6-8fae57f6076a" />

<img width="1598" height="261" alt="image" src="https://github.com/user-attachments/assets/18011f67-5abb-49c3-ae77-23cd03245ae9" />

🚀 Preview: Add `preview` label to enable