### PR TITLE
Rename Tools nav item to Resources

### DIFF
--- a/monorepo/website/src/components/ExternalTools/NoToolsAvailable.astro
+++ b/monorepo/website/src/components/ExternalTools/NoToolsAvailable.astro
@@ -3,6 +3,6 @@
 
 <div class="text-center py-12">
     <p class="mt-2 text-gray-500">
-        There are currently no tools available.
+        There are currently no resources available.
     </p>
 </div>

--- a/monorepo/website/src/components/ExternalTools/ToolsIntegrationNotice.astro
+++ b/monorepo/website/src/components/ExternalTools/ToolsIntegrationNotice.astro
@@ -4,10 +4,10 @@ import DashiconsExternal from '~icons/dashicons/external';
 
 <div class="mt-12 8 border-t border-gray-200">
     <h3 class="text-base font-semibold text-main my-3 mt-4">
-        Want to integrate your tool?
+        Want to integrate your resource?
     </h3>
     <p>
-        We welcome integrations with external tools. Our API provides programmatic access to sequence data and metadata. If you wish to add your tool to the list, please send us a request through GitHub.
+        We welcome integrations with external resources. Our API provides programmatic access to sequence data and metadata. If you wish to add your resource to the list, please send us a request through GitHub.
     </p>
     <div class="mt-4 flex items-center gap-6">
         <a href="https://github.com/pathoplexus/pathoplexus/issues" class="outlineButton flex">

--- a/monorepo/website/src/pages/[organism]/external-resources/index.astro
+++ b/monorepo/website/src/pages/[organism]/external-resources/index.astro
@@ -1,0 +1,45 @@
+---
+import NoToolsAvailable from '../../../components/ExternalTools/NoToolsAvailable.astro';
+import ToolCard from '../../../components/ExternalTools/ToolCard.astro';
+import ToolsIntegrationNotice from '../../../components/ExternalTools/ToolsIntegrationNotice.astro';
+import { tools } from '../../../components/ExternalTools/tools';
+import { cleanOrganism } from '../../../components/Navigation/cleanOrganism';
+import BaseLayout from "../../../layouts/BaseLayout.astro";
+
+const { organism } = cleanOrganism(Astro.params.organism);
+
+if (!organism) {
+    return {
+        statusCode: 404,
+        body: 'Organism not found',
+    };
+}
+
+const relevantTools = tools.filter(tool =>
+    tool.organisms.includes(organism.key)
+).sort((a, b) => a.name > b.name ? 1 : -1);
+---
+
+<BaseLayout title='External resources'>
+    <div class='max-w-3xl mx-auto text-gray-700'>
+        <h1 class='text-2xl font-semibold text-main my-3 mt-8'>
+            External Resources for {organism.displayName}
+        </h1>
+
+        <div class='mb-3'>
+            Resources that use data from Pathoplexus:
+        </div>
+
+        {relevantTools.length > 0 ? (
+            <div class="space-y-6">
+                {relevantTools.map(tool => (
+                    <ToolCard tool={tool} selectedOrganism={organism.key} />
+                ))}
+            </div>
+        ) : (
+            <NoToolsAvailable />
+        )}
+
+        <ToolsIntegrationNotice />
+    </div>
+</BaseLayout>

--- a/monorepo/website/src/pages/[organism]/external-tools/index.astro
+++ b/monorepo/website/src/pages/[organism]/external-tools/index.astro
@@ -1,10 +1,5 @@
 ---
-import NoToolsAvailable from '../../../components/ExternalTools/NoToolsAvailable.astro';
-import ToolCard from '../../../components/ExternalTools/ToolCard.astro';
-import ToolsIntegrationNotice from '../../../components/ExternalTools/ToolsIntegrationNotice.astro';
-import { tools } from '../../../components/ExternalTools/tools';
 import { cleanOrganism } from '../../../components/Navigation/cleanOrganism';
-import BaseLayout from "../../../layouts/BaseLayout.astro";
 
 const { organism } = cleanOrganism(Astro.params.organism);
 
@@ -15,31 +10,5 @@ if (!organism) {
     };
 }
 
-const relevantTools = tools.filter(tool =>
-    tool.organisms.includes(organism.key)
-).sort((a, b) => a.name > b.name ? 1 : -1);
+return Astro.redirect(`/${organism.key}/external-resources`, 301);
 ---
-
-<BaseLayout title='External tools'>
-    <div class='max-w-3xl mx-auto text-gray-700'>
-        <h1 class='text-2xl font-semibold text-main my-3 mt-8'>
-            External Resources for {organism.displayName}
-        </h1>
-
-        <div class='mb-3'>
-            Resources that use data from Pathoplexus:
-        </div>
-
-        {relevantTools.length > 0 ? (
-            <div class="space-y-6">
-                {relevantTools.map(tool => (
-                    <ToolCard tool={tool} selectedOrganism={organism.key} />
-                ))}
-            </div>
-        ) : (
-            <NoToolsAvailable />
-        )}
-
-        <ToolsIntegrationNotice />
-    </div>
-</BaseLayout>

--- a/monorepo/website/src/pages/[organism]/external-tools/index.astro
+++ b/monorepo/website/src/pages/[organism]/external-tools/index.astro
@@ -23,11 +23,11 @@ const relevantTools = tools.filter(tool =>
 <BaseLayout title='External tools'>
     <div class='max-w-3xl mx-auto text-gray-700'>
         <h1 class='text-2xl font-semibold text-main my-3 mt-8'>
-            External Tools for {organism.displayName}
+            External Resources for {organism.displayName}
         </h1>
 
         <div class='mb-3'>
-            Tools that use data from Pathoplexus:
+            Resources that use data from Pathoplexus:
         </div>
 
         {relevantTools.length > 0 ? (

--- a/monorepo/website/src/routes/extraTopNavigationItems.ts
+++ b/monorepo/website/src/routes/extraTopNavigationItems.ts
@@ -1,6 +1,6 @@
 // The following code is in a separate file so that it can be overwritten by Pathoplexus.
 import type { TopNavigationItems } from './navigationItems.ts';
-import ToolIcon from '~icons/tabler/tool';
+import PresentationIcon from '~icons/tabler/presentation';
 
 export const extraStaticTopNavigationItems = [
     {
@@ -18,10 +18,10 @@ export const extraStaticTopNavigationItems = [
 ];
 
 export const extraSequenceRelatedTopNavigationItems = (organism: string | undefined): TopNavigationItems => {
-    const tools = {
-        text: 'Tools',
+    const resources = {
+        text: 'Resources',
         path: `/${organism}/external-tools`,
-        icon: ToolIcon,
+        icon: PresentationIcon,
     }
-    return [tools];
+    return [resources];
 }

--- a/monorepo/website/src/routes/extraTopNavigationItems.ts
+++ b/monorepo/website/src/routes/extraTopNavigationItems.ts
@@ -20,7 +20,7 @@ export const extraStaticTopNavigationItems = [
 export const extraSequenceRelatedTopNavigationItems = (organism: string | undefined): TopNavigationItems => {
     const resources = {
         text: 'Resources',
-        path: `/${organism}/external-tools`,
+        path: `/${organism}/external-resources`,
         icon: PresentationIcon,
     }
     return [resources];


### PR DESCRIPTION
Change the top navigation menu label from "Tools" to "Resources" and update the icon to tabler:presentation, and update text

<img width="1131" height="605" alt="image" src="https://github.com/user-attachments/assets/491650b1-b044-4d00-b672-0f494386c019" />

🚀 Preview: https://preview-resource.pathoplexus.org