### PR TITLE
Andes and BDBV improvements

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2324,7 +2324,6 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 1
           - 2
         configFile:
           <<: *preprocessingConfigFile
@@ -2332,6 +2331,33 @@ organisms:
           taxon_id: 1980456
           scientific_name: "Andes Virus"
           molecule_type: "genomic RNA"
+          nextclade_dataset_server: "https://pathoplexus.github.io/reference_store/andv/nextclade_data"
+          segments:
+            - name: L
+              references:
+                - name: singleReference
+                  nextclade_dataset_name: andv/L
+                  genes: [RdRp]
+            - name: M
+              references:
+                - name: singleReference
+                  nextclade_dataset_name: andv/M
+                  genes: [GPC]
+            - name: S
+              references:
+                - name: singleReference
+                  nextclade_dataset_name: andv/S
+                  genes: ["N", NSs]
+      - <<: *preprocessing
+        version:
+          - 2
+        configFile:
+          <<: *preprocessingConfigFile
+          create_embl_file: false
+          taxon_id: 1980456
+          scientific_name: "Andes Virus"
+          molecule_type: "genomic RNA"
+          alignment_requirement: ANY
           nextclade_dataset_server: "https://pathoplexus.github.io/reference_store/andv/nextclade_data"
           segments:
             - name: L

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1817,6 +1817,20 @@ organisms:
             inputs: {input: nextclade.customNodeAttributes.outbreak}
           order: 5
           orderOnDetailsPage: 740
+        - name: mutationsFromOutbreakFounder
+          header: "Outbreak"
+          displayName: "Amino acid substitutions from outbreak clade founder"
+          customDisplay:
+            type: generatedBadge
+          noInput: true
+          generateIndex: false
+          autocomplete: false
+          initiallyVisible: false
+          includeInDownloadsByDefault: false
+          preprocessing:
+            inputs: {input: "nextclade.cladeNodeAttrFounderInfo.outbreak.aaMutations.*.privateSubstitutions"}
+          order: 95
+          orderOnDetailsPage: 95
       website:
         <<: *website
         tableColumns:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2012,6 +2012,7 @@ organisms:
         <<: *preprocessing
         version:
           - 28
+          - 29
         replicas: 1
         configFile:
           <<: *preprocessingConfigFile
@@ -2632,6 +2633,7 @@ organisms:
         replicas: 1
         version:
           - 18
+          - 19
         configFile:
           <<: *preprocessingConfigFile
           batch_size: 5
@@ -3259,6 +3261,7 @@ organisms:
       - <<: *preprocessing
         version:
           - 19
+          - 20
         replicas: 1
         configFile:
           <<: *preprocessingConfigFile
@@ -3399,6 +3402,7 @@ organisms:
       - <<: *preprocessing
         version:
           - 20
+          - 21
         replicas: 1
         configFile:
           <<: *preprocessingConfigFile
@@ -3633,6 +3637,7 @@ organisms:
       - <<: *preprocessing
         version:
           - 25
+          - 26
         replicas: 1
         configFile:
           <<: *preprocessingConfigFile

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2372,6 +2372,8 @@ organisms:
           scientific_name: "Andes Virus"
           molecule_type: "genomic RNA"
           alignment_requirement: ANY
+          segment_classification_method: minimizer
+          minimizer_url: "https://pathoplexus.github.io/reference_store/andv/segment-minimizer.json"
           nextclade_dataset_server: "https://pathoplexus.github.io/reference_store/andv/nextclade_data"
           segments:
             - name: L

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2037,34 +2037,6 @@ organisms:
                   nextclade_dataset_name: community/v-gen-lab/dengue/denv4
                   nextclade_dataset_tag: 2025-09-09--12-13-13Z
                   genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
-      - <<: *preprocessing
-        version:
-          - 29
-        replicas: 3
-        configFile:
-          <<: *preprocessingConfigFile
-          segment_classification_method: "minimizer"
-          create_embl_file: false
-          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/dengue/minimizer.json"
-          segments:
-            - name: main
-              references:
-                - name: DENV-1
-                  nextclade_dataset_name: community/v-gen-lab/dengue/denv1
-                  nextclade_dataset_tag: 2025-09-09--12-13-13Z
-                  genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
-                - name: DENV-2
-                  nextclade_dataset_name: community/v-gen-lab/dengue/denv2
-                  nextclade_dataset_tag: 2025-09-09--12-13-13Z
-                  genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
-                - name: DENV-3
-                  nextclade_dataset_name: community/v-gen-lab/dengue/denv3
-                  nextclade_dataset_tag: 2025-09-09--12-13-13Z
-                  genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
-                - name: DENV-4
-                  nextclade_dataset_name: community/v-gen-lab/dengue/denv4
-                  nextclade_dataset_tag: 2025-09-09--12-13-13Z
-                  genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
       - <<: *denguePreprocessing
         version:
           - 29

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2338,7 +2338,7 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 2
+          - 1
         configFile:
           <<: *preprocessingConfigFile
           create_embl_file: false

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2012,8 +2012,35 @@ organisms:
         <<: *preprocessing
         version:
           - 28
-          - 29
         replicas: 1
+        configFile:
+          <<: *preprocessingConfigFile
+          segment_classification_method: "minimizer"
+          create_embl_file: false
+          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/dengue/minimizer.json"
+          segments:
+            - name: main
+              references:
+                - name: DENV-1
+                  nextclade_dataset_name: community/v-gen-lab/dengue/denv1
+                  nextclade_dataset_tag: 2025-09-09--12-13-13Z
+                  genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
+                - name: DENV-2
+                  nextclade_dataset_name: community/v-gen-lab/dengue/denv2
+                  nextclade_dataset_tag: 2025-09-09--12-13-13Z
+                  genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
+                - name: DENV-3
+                  nextclade_dataset_name: community/v-gen-lab/dengue/denv3
+                  nextclade_dataset_tag: 2025-09-09--12-13-13Z
+                  genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
+                - name: DENV-4
+                  nextclade_dataset_name: community/v-gen-lab/dengue/denv4
+                  nextclade_dataset_tag: 2025-09-09--12-13-13Z
+                  genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
+      - <<: *preprocessing
+        version:
+          - 29
+        replicas: 3
         configFile:
           <<: *preprocessingConfigFile
           segment_classification_method: "minimizer"
@@ -2633,7 +2660,6 @@ organisms:
         replicas: 1
         version:
           - 18
-          - 19
         configFile:
           <<: *preprocessingConfigFile
           batch_size: 5
@@ -3261,7 +3287,6 @@ organisms:
       - <<: *preprocessing
         version:
           - 19
-          - 20
         replicas: 1
         configFile:
           <<: *preprocessingConfigFile
@@ -3402,7 +3427,6 @@ organisms:
       - <<: *preprocessing
         version:
           - 20
-          - 21
         replicas: 1
         configFile:
           <<: *preprocessingConfigFile
@@ -3637,7 +3661,6 @@ organisms:
       - <<: *preprocessing
         version:
           - 25
-          - 26
         replicas: 1
         configFile:
           <<: *preprocessingConfigFile

--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: f091cc10a7f48e55e70c2856d45450acf601d4d0
+loculusVersion: 210853b8784aa8093b67ae657c1eee51ed84110d
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy

--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 210853b8784aa8093b67ae657c1eee51ed84110d
+loculusVersion: 7215e5b5c9d83ef6bf1f5251e1b50fb4c1e51108
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
https://github.com/pathoplexus/pathoplexus/issues/982, https://github.com/pathoplexus/pathoplexus/issues/930

Things to test:
- [x] more andes sequences as now assigned but not aligned sequences are still accepted
nice only 29 single sequences failed preprocessing all because they had sequences that could be aligned 
<img width="2196" height="578" alt="image" src="https://github.com/user-attachments/assets/3ff6f1c7-a0ce-46e4-bb44-3aacc90c8b58" />

- [x] confirm cannot submit an invalid segment e.g. an rsv sequence as an andes segment
<img width="2216" height="908" alt="image" src="https://github.com/user-attachments/assets/55f88087-fd7e-4ee3-96d2-f4f08d45b113" />

- [x] mutations from outbreak clade founder is correct for BDBV
nice! this works but needs a small code change 
<img width="814" height="362" alt="image" src="https://github.com/user-attachments/assets/c0f13e6b-2644-4f04-84d3-91850d9b057c" />

- [x] test new grouping introduced by https://github.com/loculus-project/loculus/pull/6527

Claude's summary:

### Segment Grouping Changes
  
  Three grouping improvement patterns:

  1. Individual M and S → paired M+S (5 new combined entries):
    - 3 EU564xxx pairs: EU564721.1.M + EU564715.1.S → EU564721.1.M/EU564715.1.S (and 2 more)
    - 2 OR987854/855 pairs: OR987854.1.M + OR908892.1.S → OR987854.1.M/OR908892.1.S (and 1 more)
  2. Existing L+M groups gained their S segment (6 entries):
    - PP003836/37 (were L+M only) → full L+M+S by adding OR908897/898.S
    - PP151168-170, PP151172 (were L+M only) → full L+M+S by adding OR90888x.S
  3. Individual L, M, S → full L+M+S (6 entries):
    - PP151165/166/167, PP504849 (individual L segments) + separate M and S → combined L+M+S
    - PQ373861.1.L + PQ356349.1.M + PQ181488.2.S → single combined entry

  ---
  New Sequences
  
  - 25 "new" EU170xxx M+S pairs — all from Brazil (Araraquara virus, host: Necromys lasiurus), OPEN, INSDC-ingested, dated 2004-06. These have no counterpart in the removed
  section — genuine new additions. (These are sequences where the M segment could not be aligned only assigned and with the alignmenttype ANY are now visible on PPX)

  ---
  Removed Sequences — Restriction Check
  
  All 20 truly removed sequences are RESTRICTED. The OPEN sequences appearing in the removed list (all the EU564xxx, ORxxx, PPxxx, PQxxx) are not actually lost — they are regrouped into combined entries in the added section.

🚀 Preview: Add `preview` label to enable