### PR TITLE
go back to batch size 10

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2824,7 +2824,7 @@ organisms:
           - 19
         configFile:
           <<: *preprocessingConfigFile
-          batch_size: 50
+          batch_size: 10
           segments:
             - <<: *mpoxDataset
     ingest:


### PR DESCRIPTION
Mpox reprocessing is failing due to a lot of timeouts - Cornelius tested that a smaller batch size is better for rollouts, thus going back to old settings