### PR TITLE
feat: give staging backend more cpu for reprocessing

### DIFF
--- a/loculus_values/environment_specific_values/staging.yaml
+++ b/loculus_values/environment_specific_values/staging.yaml
@@ -77,5 +77,12 @@ defaultResources:
   limits:
     memory: "1Gi"
     cpu: "1000m"
+resources:
+  backend:
+    requests:
+      memory: "1Gi"
+      cpu: "1000m"
+    limits:
+      memory: "3Gi" # Backend requires at least 635741K of memory
 siloImport:
   pollIntervalSeconds: 60


### PR DESCRIPTION
Give the staging backend the same requests as prod (exspecially more cpu is needed for reprocessing)

This is an increase from the default used by main and previews:
```
backend:
    requests:
      memory: "640Mi"
      cpu: "100m"
    limits:
      memory: "3Gi" # Backend requires at least 635741K of memory
```