### PR TITLE
test if using lower zstd compression level 10 reduces backend cpu measurably

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -72,7 +72,7 @@ siloImport:
   hardRefreshIntervalSeconds: 100_000 # ~27 hours
   pollIntervalSeconds: 120
 pipelineVersionUpgradeCheckIntervalSeconds: 300
-zstdCompressionLevel: 20
+zstdCompressionLevel: 10
 lineageSystemDefinitions:
   mpox:
     18: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2025-09-09--12-13-13Z/lineages.yaml


### PR DESCRIPTION
🚀 Preview: Add `preview` label to enable