### PR TITLE
test if rarely calling get released data (20min) reduces backend cpu measurably

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -70,7 +70,7 @@ sequenceFlagging:
 siloImport:
   siloTimeoutSeconds: 3600
   hardRefreshIntervalSeconds: 100_000 # ~27 hours
-  pollIntervalSeconds: 120
+  pollIntervalSeconds: 1200
 pipelineVersionUpgradeCheckIntervalSeconds: 300
 zstdCompressionLevel: 20
 lineageSystemDefinitions:


### PR DESCRIPTION
🚀 Preview: Add `preview` label to enable