### PR TITLE
test reducing zstd to 15 (also slow silo import to separate out)

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -70,7 +70,7 @@ sequenceFlagging:
 siloImport:
   siloTimeoutSeconds: 3600
   hardRefreshIntervalSeconds: 100_000 # ~27 hours
-  pollIntervalSeconds: 120
+  pollIntervalSeconds: 1200
 pipelineVersionUpgradeCheckIntervalSeconds: 300
 zstdCompressionLevel: 20
 lineageSystemDefinitions:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -72,7 +72,7 @@ siloImport:
   hardRefreshIntervalSeconds: 100_000 # ~27 hours
   pollIntervalSeconds: 1200
 pipelineVersionUpgradeCheckIntervalSeconds: 300
-zstdCompressionLevel: 20
+zstdCompressionLevel: 15
 lineageSystemDefinitions:
   mpox:
     18: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2025-09-09--12-13-13Z/lineages.yaml


### PR DESCRIPTION
- **test if rarely calling get released data (20min) reduces backend cpu measurably**
- **Reduce zstd level to 15**

🚀 Preview: Add `preview` label to enable