### PR TITLE
feat(andv, ebola-bdbv): add alignment improvements and mutations from outbreak clade founder

### DIFF
--- a/loculus_values/environment_specific_values/production.yaml
+++ b/loculus_values/environment_specific_values/production.yaml
@@ -210,4 +210,4 @@ sequenceFlagging:
   github:
     issueTemplate: sequence-metadata-issue.md
 siloImport:
-  pollIntervalSeconds: 120
+  pollIntervalSeconds: 30

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1817,6 +1817,20 @@ organisms:
             inputs: {input: nextclade.customNodeAttributes.outbreak}
           order: 5
           orderOnDetailsPage: 740
+        - name: mutationsFromOutbreakFounder
+          header: "Outbreak"
+          displayName: "Amino acid substitutions from outbreak clade founder"
+          customDisplay:
+            type: generatedBadge
+          noInput: true
+          generateIndex: false
+          autocomplete: false
+          initiallyVisible: false
+          includeInDownloadsByDefault: false
+          preprocessing:
+            inputs: {input: "nextclade.cladeNodeAttrFounderInfo.outbreak.aaMutations.*.privateSubstitutions"}
+          order: 95
+          orderOnDetailsPage: 95
       website:
         <<: *website
         tableColumns:
@@ -2332,6 +2346,9 @@ organisms:
           taxon_id: 1980456
           scientific_name: "Andes Virus"
           molecule_type: "genomic RNA"
+          alignment_requirement: ANY
+          segment_classification_method: minimizer
+          minimizer_url: "https://pathoplexus.github.io/reference_store/andv/segment-minimizer.json"
           nextclade_dataset_server: "https://pathoplexus.github.io/reference_store/andv/nextclade_data"
           segments:
             - name: L

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -72,7 +72,7 @@ siloImport:
   hardRefreshIntervalSeconds: 100_000 # ~27 hours
   pollIntervalSeconds: 120
 pipelineVersionUpgradeCheckIntervalSeconds: 300
-zstdCompressionLevel: 20
+zstdCompressionLevel: 15
 lineageSystemDefinitions:
   mpox:
     19: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2025-09-09--12-13-13Z/lineages.yaml

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -75,25 +75,18 @@ pipelineVersionUpgradeCheckIntervalSeconds: 300
 zstdCompressionLevel: 20
 lineageSystemDefinitions:
   mpox:
-    18: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2025-09-09--12-13-13Z/lineages.yaml
     19: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2025-09-09--12-13-13Z/lineages.yaml
   rsv-a:
-    19: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
     20: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
   rsv-b:
-    20: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-b/2025-08-25--09-00-35Z/lineages.yaml
     21: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-b/2025-08-25--09-00-35Z/lineages.yaml
   hmpv:
-    21: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/hmpv/2025-09-09--12-13-13Z/lineages.yaml
     22: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/hmpv/2025-09-09--12-13-13Z/lineages.yaml
   cchfS:
-    21: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/cchf/S/2025-09-24--07-29-03Z/lineages.yaml
     22: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/cchf/S/2025-09-24--07-29-03Z/lineages.yaml
   marburg:
-    22: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/marburg/2025-09-09--12-13-13Z/lineages.yaml
     23: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/marburg/2025-09-09--12-13-13Z/lineages.yaml
   dengue:
-    28: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/dengue/all/2025-09-09--12-13-13Z/lineages.yaml
     29: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/dengue/all/2025-09-09--12-13-13Z/lineages.yaml
 defaultOrganismConfig: &defaultOrganismConfig
   schema: &schema
@@ -1675,7 +1668,6 @@ organisms:
       - <<: *preprocessing
         replicas: 1
         version:
-          - 27
           - 28
         configFile:
           <<: *preprocessingConfigFile
@@ -1739,7 +1731,6 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 24
           - 25
         configFile:
           <<: *preprocessingConfigFile
@@ -1846,8 +1837,8 @@ organisms:
       - &ebolaBdbvPreprocessing
         <<: *preprocessing
         version:
-          - 2
           - 3
+          - 4
         configFile: &ebolaBdbvPreprocessingConfigFile
           <<: *preprocessingConfigFile
           segments:
@@ -2025,7 +2016,7 @@ organisms:
       - &denguePreprocessing
         <<: *preprocessing
         version:
-          - 28
+          - 29
         replicas: 1
         configFile:
           <<: *preprocessingConfigFile
@@ -2051,10 +2042,6 @@ organisms:
                   nextclade_dataset_name: community/v-gen-lab/dengue/denv4
                   nextclade_dataset_tag: 2025-09-09--12-13-13Z
                   genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
-      - <<: *denguePreprocessing
-        version:
-          - 29
-        replicas: 3
     ingest:
       <<: *ingest
       configFile:
@@ -2241,7 +2228,6 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 25
           - 26
         configFile:
           <<: *preprocessingConfigFile
@@ -2338,8 +2324,33 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 1
           - 2
+        configFile:
+          <<: *preprocessingConfigFile
+          create_embl_file: false
+          taxon_id: 1980456
+          scientific_name: "Andes Virus"
+          molecule_type: "genomic RNA"
+          nextclade_dataset_server: "https://pathoplexus.github.io/reference_store/andv/nextclade_data"
+          segments:
+            - name: L
+              references:
+                - name: singleReference
+                  nextclade_dataset_name: andv/L
+                  genes: [RdRp]
+            - name: M
+              references:
+                - name: singleReference
+                  nextclade_dataset_name: andv/M
+                  genes: [GPC]
+            - name: S
+              references:
+                - name: singleReference
+                  nextclade_dataset_name: andv/S
+                  genes: ["N", NSs]
+      - <<: *preprocessing
+        version:
+          - 3
         configFile:
           <<: *preprocessingConfigFile
           create_embl_file: false
@@ -2485,7 +2496,6 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 21
           - 22
         configFile:
           <<: *preprocessingConfigFile
@@ -2648,7 +2658,7 @@ organisms:
         <<: *preprocessing
         replicas: 1
         version:
-          - 18
+          - 19
         configFile:
           <<: *preprocessingConfigFile
           batch_size: 5
@@ -2835,15 +2845,15 @@ organisms:
                   - OPG208
                   - OPG209
                   - OPG210
-      - <<: *mpoxPreprocessing
-        replicas: 3
-        version:
-          - 19
-        configFile:
-          <<: *preprocessingConfigFile
-          batch_size: 10
-          segments:
-            - <<: *mpoxDataset
+      # - <<: *mpoxPreprocessing
+      #   replicas: 3
+      #   version:
+      #     - 19
+      #   configFile:
+      #     <<: *preprocessingConfigFile
+      #     batch_size: 10
+      #     segments:
+      #       - <<: *mpoxDataset
     ingest:
       <<: *ingest
       configFile:
@@ -3275,25 +3285,8 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 19
-        replicas: 1
-        configFile:
-          <<: *preprocessingConfigFile
-          segments:
-            - name: main
-              references:
-              - name: singleReference
-                genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
-                nextclade_dataset_name: "nextstrain/rsv/a/EPI_ISL_412866"
-                nextclade_dataset_tag: "2025-08-25--09-00-35Z"
-                accepted_dataset_matches: 
-                  - rsv-a
-          require_nextclade_sort_match: true
-          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
-      - <<: *preprocessing
-        version:
           - 20
-        replicas: 2
+        replicas: 1
         configFile:
           <<: *preprocessingConfigFile
           segments:
@@ -3415,25 +3408,8 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 20
-        replicas: 1
-        configFile:
-          <<: *preprocessingConfigFile
-          segments:
-            - name: main
-              references:
-              - name: singleReference
-                nextclade_dataset_name: "nextstrain/rsv/b/EPI_ISL_1653999"
-                nextclade_dataset_tag: "2025-08-25--09-00-35Z"
-                accepted_dataset_matches:
-                  - rsv-b
-                genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
-          require_nextclade_sort_match: true
-          minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
-      - <<: *preprocessing
-        version:
           - 21
-        replicas: 2
+        replicas: 1
         configFile:
           <<: *preprocessingConfigFile
           segments:
@@ -3545,7 +3521,6 @@ organisms:
       - <<: *preprocessing
         replicas: 1
         version:
-          - 21
           - 22
         configFile:
           <<: *preprocessingConfigFile
@@ -3649,21 +3624,8 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 25
-        replicas: 1
-        configFile:
-          <<: *preprocessingConfigFile
-          segments:
-            - name: main
-              references:
-              - name: singleReference
-                nextclade_dataset_name: "nextstrain/measles/genome/WHO-2012"
-                nextclade_dataset_tag: "2025-08-11--19-06-01Z"
-                genes: [ "C", "F", "H", "L", "M", "N", "P", "V" ]
-      - <<: *preprocessing
-        version:
           - 26
-        replicas: 2
+        replicas: 1
         configFile:
           <<: *preprocessingConfigFile
           segments:
@@ -3758,7 +3720,6 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 22
           - 23
         replicas: 1
         configFile:
@@ -3898,7 +3859,6 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 27
           - 28
         configFile:
           <<: *preprocessingConfigFile

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2349,22 +2349,22 @@ organisms:
           alignment_requirement: ANY
           segment_classification_method: minimizer
           minimizer_url: "https://pathoplexus.github.io/reference_store/andv/segment-minimizer.json"
-          nextclade_dataset_server: "https://pathoplexus.github.io/reference_store/andv/nextclade_data"
+          nextclade_dataset_tag: "2026-05-29--13-46-38Z"
           segments:
             - name: L
               references:
                 - name: singleReference
-                  nextclade_dataset_name: andv/L
+                  nextclade_dataset_name: nextstrain/orthohantavirus/andv/l
                   genes: [RdRp]
             - name: M
               references:
                 - name: singleReference
-                  nextclade_dataset_name: andv/M
+                  nextclade_dataset_name: nextstrain/orthohantavirus/andv/m
                   genes: [GPC]
             - name: S
               references:
                 - name: singleReference
-                  nextclade_dataset_name: andv/S
+                  nextclade_dataset_name: nextstrain/orthohantavirus/andv/s
                   genes: ["N", NSs]
     ingest:
       <<: *ingest


### PR DESCRIPTION
resolves: https://github.com/pathoplexus/pathoplexus/issues/982, https://github.com/pathoplexus/pathoplexus/issues/930, https://github.com/pathoplexus/pathoplexus/issues/993

- removes outdated prepro pipeline versions and reduces replicas
- adds new mutations from outbreak clade founder metadata field
- improves alignment for andes: uses official nextclade dataset and uses alignment_requirement: ANY, i.e. also accept submissions with a segment that can be assigned but not aligned (if segment cannot be assigned still reject)
- reprocess andes and ebola bdbv


Things to test:
(copied from https://github.com/pathoplexus/pathoplexus/pull/983 as preview is currently overwhelmed) 
- [x] more andes sequences as now assigned but not aligned sequences are still accepted
nice only 29 single sequences failed preprocessing all because they had sequences that could be aligned 
<img width="2196" height="578" alt="image" src="https://github.com/user-attachments/assets/3ff6f1c7-a0ce-46e4-bb44-3aacc90c8b58" />

- [x] confirm cannot submit an invalid segment e.g. an rsv sequence as an andes segment
<img width="2216" height="908" alt="image" src="https://github.com/user-attachments/assets/55f88087-fd7e-4ee3-96d2-f4f08d45b113" />

- [x] mutations from outbreak clade founder is correct for BDBV
<img width="814" height="362" alt="image" src="https://github.com/user-attachments/assets/c0f13e6b-2644-4f04-84d3-91850d9b057c" />

🚀 Preview: https://preview-nextclade.pathoplexus.org