### PR TITLE
feat(website): add outbreak hint box to "Using All Data" data use terms

### DIFF
--- a/monorepo/website/src/components/asides/OutbreakHintBox.astro
+++ b/monorepo/website/src/components/asides/OutbreakHintBox.astro
@@ -1,0 +1,31 @@
+---
+import MaterialSymbolsCoronavirus from '~icons/material-symbols/coronavirus';
+
+interface Props {
+    title?: string;
+}
+
+const { title = 'In outbreak settings' } = Astro.props;
+---
+
+<div
+    class='outbreak-hint-box my-4 flex items-start gap-3 rounded-lg border border-rose-200 border-l-4 border-l-rose-500 bg-rose-50 p-4 text-sm shadow-sm'
+>
+    <span class='mt-0.5 shrink-0 text-xl leading-none text-rose-600'>
+        <MaterialSymbolsCoronavirus />
+    </span>
+    <div class='text-rose-900'>
+        <p class='mb-1 font-semibold text-rose-800'>{title}</p>
+        <slot />
+    </div>
+</div>
+
+<style is:global>
+    .outbreak-hint-box a {
+        @apply font-medium text-rose-700 underline;
+    }
+
+    .outbreak-hint-box a:hover {
+        @apply text-rose-900;
+    }
+</style>

--- a/monorepo/website/src/components/asides/OutbreakHintBox.astro
+++ b/monorepo/website/src/components/asides/OutbreakHintBox.astro
@@ -9,23 +9,23 @@ const { title = 'In outbreak settings' } = Astro.props;
 ---
 
 <div
-    class='outbreak-hint-box my-4 flex items-start gap-3 rounded-lg border border-rose-200 border-l-4 border-l-rose-500 bg-rose-50 p-4 text-sm shadow-sm'
+    class='outbreak-hint-box my-4 rounded-lg border border-amber-300 border-l-4 border-l-amber-500 bg-amber-50 p-4 text-sm shadow-sm text-amber-900'
 >
-    <span class='mt-0.5 shrink-0 text-xl leading-none text-rose-600'>
-        <MaterialSymbolsCoronavirus />
-    </span>
-    <div class='text-rose-900'>
-        <p class='mb-1 font-semibold text-rose-800'>{title}</p>
-        <slot />
-    </div>
+    <p class='mb-1 text-base inline-flex items-center font-bold text-amber-800'>
+        <span class='inline-block mr-2 text-xl leading-none text-amber-600'>
+            <MaterialSymbolsCoronavirus />
+        </span>
+        <span><span class='uppercase tracking-wide'>Hint:</span> {title}</span>
+    </p>
+    <slot />
 </div>
 
 <style is:global>
     .outbreak-hint-box a {
-        @apply font-medium text-rose-700 underline;
+        @apply font-medium text-amber-700 underline;
     }
 
     .outbreak-hint-box a:hover {
-        @apply text-rose-900;
+        @apply text-amber-900;
     }
 </style>

--- a/monorepo/website/src/pages/about/terms-of-use/data-use-terms.mdx
+++ b/monorepo/website/src/pages/about/terms-of-use/data-use-terms.mdx
@@ -4,6 +4,8 @@ title: "Data Use Terms"
 order: 1
 ---
 
+import OutbreakHintBox from '../../../components/asides/OutbreakHintBox.astro';
+
 Summaries of our Data Use Terms for [Open Data](/about/terms-of-use/open-data) and [Restricted-Use Data](/about/terms-of-use/restricted-data) are also available. Note that only the **full** Data Use Terms are used to interpret and arbitrate use. 
 
 ---
@@ -140,6 +142,15 @@ Restricted-Use Data from Pathoplexus can be shared onward but the [Data Use Term
 The focus of Pathoplexus is on open availability of data. If Users share Restricted-Use Pathoplexus data onward as a database or as part of a database it must be under the same circumstances as it has been provided to User: without access restrictions. An exception is made for private use for small groups or labs with up to 200 users. If Users wish to use Pathoplexus data in an access-restricted database with more than 200 users, Users must contact Pathoplexus to request permission ([help@pathoplexus.org](mailto:help@pathoplexus.org)). We generally support onward sharing for collaborative use (such as access within an institution for their employees, or sharing within a collaboration for joint downstream analysis) and encourage you to reach out. Requests will be considered and decided by the Executive Board.
 
 ## 4.3 Using All Data
+
+<OutbreakHintBox>
+    Treating your entire dataset as a "Background Set" is generally **not appropriate in an outbreak
+    setting**. During an outbreak, the majority of the most important and timely data is typically
+    Restricted-Use and has been contributed by only a small number of submitting groups. In that
+    situation, using all data without contacting and involving those submitters would not be ethical —
+    such data should be treated as part of your [Focal Set](#423-deciding-if-restricted-use-data-is-part-of-a-focal-or-background-set)
+    and used under the [Restricted Data Use](#42-restricted-data-use) requirements.
+</OutbreakHintBox>
 
 In some cases there are a large number of data submitters that have contributed to the database and in these cases, analyses and applications that use all data from the database can consider this data as "Background Set" without explicit involvement of the submitters. In other cases, where only a small number of groups have contributed, it would not be ethical to use all data without contacting and involving the submitting groups.
 


### PR DESCRIPTION
## What

Adds a stylised hint box under **§4.3 "Using All Data"** on the Data Use Terms page, explicitly labelled **HINT**, warning that treating an entire dataset as a "Background Set" is generally **not appropriate in outbreak settings**, where the majority of the important and timely data is Restricted-Use and contributed by only a small number of submitting groups.

## Screenshot

Preview of the new hint box rendered under §4.3:

![Outbreak HINT box under section 4.3 Using All Data](https://raw.githubusercontent.com/loculus-project/agent_store/main/pathoplexus-pr1001/outbreak-hint-box-v2.png)

## Changes

Two files:

1. **New component `monorepo/website/src/components/asides/OutbreakHintBox.astro`** — a new aside, deliberately distinct from the existing `InfoBox` (blue/"Note") and `CautionBox` (amber/"Caution"). It uses an amber colour scheme with a left accent border and soft shadow, a coronavirus icon, and an explicit **`HINT:`** lead followed by a title (`In outbreak settings` by default, overridable via a `title` prop). It mirrors the structure/conventions of the existing aside components (`~icons/material-symbols/…`, `<style is:global>` with `@apply`, `<slot />`).
2. **`monorepo/website/src/pages/about/terms-of-use/data-use-terms.mdx`** — imports the component and renders it immediately under the `## 4.3 Using All Data` heading. The copy links to the existing [Focal/Background Set guidance (§4.2.3)](#423-deciding-if-restricted-use-data-is-part-of-a-focal-or-background-set) and the [Restricted Data Use (§4.2)](#42-restricted-data-use) requirements.

## Why

Section 4.3 currently explains when it *can* be appropriate to treat all data as a Background Set, but does not call out the outbreak scenario, where that reasoning typically does **not** hold: the most valuable data is usually still under restriction and held by few groups, so using all of it without involving those submitters would not be ethical. The hint box surfaces this prominently at the point a reader is most likely to misapply the "Using All Data" guidance.

## Notes

- Both files are editable Pathoplexus overlays (not synced/ignored). `sync.sh` runs `rsync -av --ignore-existing` with no `--delete`, so the edit and the new component persist across syncs.
- The screenshot above is a faithful standalone render of the component (same Tailwind classes + the real `material-symbols/coronavirus` icon); the page was not built locally because `node_modules` is not installed in this checkout. A `npm run check-types` / build before merge is advisable.
- Marked as **draft**. Styling (colour, icon, title, wording) is easy to adjust if reviewers prefer a different treatment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)