### PR TITLE
feat(config): Hierarchical filter configuration for hostTaxonId

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1325,6 +1325,8 @@ defaultOrganismConfig: &defaultOrganismConfig
         guidance: "Use https://www.ncbi.nlm.nih.gov/Taxonomy/Browser/wwwtax.cgi to find taxon ids."
         example: "9606"
         noInput: true
+        hierarchicalFilter: *taxonomy_service_url
+        hierarchicalSearchLabel: "include subtaxa"
         preprocessing:
           function: resolve_host_taxon_id
           inputs:
@@ -1943,8 +1945,6 @@ organisms:
         - <<: *hostTaxonIdConfig
           required: true
           initiallyVisible: true
-          hierarchicalFilter: *taxonomy_service_url
-          hierarchicalSearchLabel: "include subtaxa"
         - name: lineage
           displayName: Lineage
           definition: "Clade label assigned by Nextclade, for views on the datasets see https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/community/v-gen-lab/dengue/denv1/2025-09-09--12-13-13Z/tree.json for DENV-1, https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/community/v-gen-lab/dengue/denv2/2025-09-09--12-13-13Z/tree.json for DENV-2, https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/community/v-gen-lab/dengue/denv3/2025-09-09--12-13-13Z/tree.json for DENV-3 and https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/community/v-gen-lab/dengue/denv4/2025-09-09--12-13-13Z/tree.json for DENV-4."
@@ -2203,8 +2203,6 @@ organisms:
       metadataAdd:
         - <<: *hostTaxonIdConfig
           initiallyVisible: true
-          hierarchicalFilter: *taxonomy_service_url
-          hierarchicalSearchLabel: "include subtaxa"
         - name: lineage
           displayName: Lineage
           definition: "Clade label assigned by Nextclade, see https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/nextstrain/wnv/all-lineages/2026-03-04--12-40-26Z/tree.json for a view of the Nextclade dataset."
@@ -3809,8 +3807,6 @@ organisms:
         - <<: *hostTaxonIdConfig
           required: true
           initiallyVisible: true
-          hierarchicalFilter: *taxonomy_service_url
-          hierarchicalSearchLabel: "include subtaxa"
         - name: clade
           displayName: Clade
           definition: "Clade label assigned by Nextclade, see https://nextstrain.org/fetch/raw.githubusercontent.com/maverbiest/nextclade_data/yellow-fever-virus/data_output/community/pathoplexus/yellow-fever-virus/unreleased/tree.json for a view of the Nextclade dataset."

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1288,7 +1288,7 @@ defaultOrganismConfig: &defaultOrganismConfig
             hostTaxonId: processed.hostTaxonId
             hostNameScientific: hostNameScientific
           args:
-            taxonomy_service_url: "http://loculus-taxonomy-service:5000"
+            taxonomy_service_url: &taxonomy_service_url "http://loculus-taxonomy-service:5000"
       - name: hostNameCommon
         displayName: Host name - common
         generateIndex: true
@@ -1308,7 +1308,7 @@ defaultOrganismConfig: &defaultOrganismConfig
           inputs:
             hostTaxonId: processed.hostTaxonId
           args:
-            taxonomy_service_url: "http://loculus-taxonomy-service:5000"
+            taxonomy_service_url: *taxonomy_service_url
       - &hostTaxonIdConfig
         name: hostTaxonId
         displayName: Host taxon ID
@@ -1332,7 +1332,7 @@ defaultOrganismConfig: &defaultOrganismConfig
             hostNameScientific: hostNameScientific
             hostTaxonId: hostTaxonId
           args:
-            taxonomy_service_url: "http://loculus-taxonomy-service:5000"
+            taxonomy_service_url: *taxonomy_service_url
       - name: isLabHost
         displayName: Is lab host
         autocomplete: true
@@ -1942,6 +1942,9 @@ organisms:
       metadataAdd:
         - <<: *hostTaxonIdConfig
           required: true
+          initiallyVisible: true
+          hierarchicalFilter: *taxonomy_service_url
+          hierarchicalSearchLabel: "include subtaxa"
         - name: lineage
           displayName: Lineage
           definition: "Clade label assigned by Nextclade, for views on the datasets see https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/community/v-gen-lab/dengue/denv1/2025-09-09--12-13-13Z/tree.json for DENV-1, https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/community/v-gen-lab/dengue/denv2/2025-09-09--12-13-13Z/tree.json for DENV-2, https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/community/v-gen-lab/dengue/denv3/2025-09-09--12-13-13Z/tree.json for DENV-3 and https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/community/v-gen-lab/dengue/denv4/2025-09-09--12-13-13Z/tree.json for DENV-4."
@@ -2198,6 +2201,10 @@ organisms:
           maxNumberOfRecommendedEntries: 2500
           url: "https://www.taxonium.org/build?mode=no_genbank&startingTreeUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/West_Nile_virus_385_99/optimized.pb.gz}}&refGbffUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/West_Nile_virus_385_99/treetime_rerooted_NC_009942.1.gbff}}&refFastaUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/West_Nile_virus_385_99/treetime_rerooted_NC_009942.1.fa}}&originalMetadataUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/West_Nile_virus_385_99/metadata.tsv.gz}}&fastaUrl={{[unalignedNucleotideSequences|fasta]}}&metadataUrl={{[metadata]}}&organism={{West Nile virus}}"
       metadataAdd:
+        - <<: *hostTaxonIdConfig
+          initiallyVisible: true
+          hierarchicalFilter: *taxonomy_service_url
+          hierarchicalSearchLabel: "include subtaxa"
         - name: lineage
           displayName: Lineage
           definition: "Clade label assigned by Nextclade, see https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/nextstrain/wnv/all-lineages/2026-03-04--12-40-26Z/tree.json for a view of the Nextclade dataset."
@@ -3801,6 +3808,9 @@ organisms:
       metadataAdd:
         - <<: *hostTaxonIdConfig
           required: true
+          initiallyVisible: true
+          hierarchicalFilter: *taxonomy_service_url
+          hierarchicalSearchLabel: "include subtaxa"
         - name: clade
           displayName: Clade
           definition: "Clade label assigned by Nextclade, see https://nextstrain.org/fetch/raw.githubusercontent.com/maverbiest/nextclade_data/yellow-fever-virus/data_output/community/pathoplexus/yellow-fever-virus/unreleased/tree.json for a view of the Nextclade dataset."

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1311,7 +1311,7 @@ defaultOrganismConfig: &defaultOrganismConfig
             taxonomy_service_url: *taxonomy_service_url
       - &hostTaxonIdConfig
         name: hostTaxonId
-        displayName: Host taxon ID
+        displayName: "Host species"
         type: string
         autocomplete: true
         customDisplay:

--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 46a2057e185da2878bb4bd933d6824e7bb4ff111
+loculusVersion: 593aff07ee9b001a596f05281b838fd75f17e322
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy

--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 593aff07ee9b001a596f05281b838fd75f17e322
+loculusVersion: 46a2057e185da2878bb4bd933d6824e7bb4ff111
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
To be merged with/after https://github.com/loculus-project/loculus/pull/6575

This PR adds configuration for making `hostTaxonId` a hierarchical filter field. This adds an autocomplete component for this field in the search UI. Users can use this to select a taxon, which will by default also return all subtaxa.

The autocomplete is `initiallyVisible: true` for dengue, west-nile, and yellow fever.

Finally, the display name for `hostTaxonId` is changed to "Host species" (same as in loculus), to more accurately convey the current usage of the field.

🚀 Preview: Add `preview` label to enable