### PR TITLE
Update Loculus version (remove daisyUI) [WIP]

### DIFF
--- a/monorepo/website/src/styles/custom-colors.css
+++ b/monorepo/website/src/styles/custom-colors.css
@@ -2,9 +2,9 @@
  * Pathoplexus color overrides.
  *
  * Loculus defines the default brand palette in base.css. Pathoplexus overrides
- * only these CSS theme variables so Tailwind utilities, daisyUI semantic
- * primary colors, and runtime reads via getThemeColor() all use the
- * Pathoplexus palette without overlaying the whole base stylesheet.
+ * only these CSS theme variables so the Tailwind utilities and runtime reads
+ * via getThemeColor() all use the Pathoplexus palette without overlaying the
+ * whole base stylesheet.
  */
 :root,
 :host {

--- a/pathoplexus_app/values.yaml
+++ b/pathoplexus_app/values.yaml
@@ -1,3 +1,3 @@
-loculusVersion: 46a2057e185da2878bb4bd933d6824e7bb4ff111
+loculusVersion: 9de72af4ab78862c18a401c4355a8abbe4c61d03
 pathoplexusBranch: dummy
 pathoplexusVersion: dummy


### PR DESCRIPTION
Points the deployment at the Loculus **remove-daisyui** branch and updates the only Pathoplexus-specific thing affected.

## What

- Bump `loculusVersion` in `pathoplexus_app/values.yaml`:
  `46a2057e1…` → [`9de72af4ab78862c18a401c4355a8abbe4c61d03`](https://github.com/loculus-project/loculus/commit/9de72af4ab78862c18a401c4355a8abbe4c61d03) (loculus-project/loculus#6604, the `remove-daisyui` branch).
- Drop the now-stale "daisyUI semantic primary colors" mention from the comment in `monorepo/website/src/styles/custom-colors.css` (the override mechanism itself is unchanged).

## Why this is the only overlay change

That Loculus version removes daisyUI from the website — its component classes (`btn`, `modal`, `input`, `loading`, `alert`, `tooltip`, `dropdown`/`menu`, `tabs`, …) are replaced with shared Tailwind/Headless-UI components, and the hand-copied Flowbite form reset is replaced with the official `@tailwindcss/forms` plugin.

I checked the Pathoplexus overlay for anything this could break:

- **Colours:** `custom-colors.css` overrides only `--color-primary-*`, `--color-main`, `--color-logoSecondary`. Those theme variables are still defined in Loculus's `base.css` `@theme` (they were never daisyUI-specific), and `base.css` is still imported before `custom-colors.css` in `BaseLayout.astro`, so the Pathoplexus palette still wins. ✅
- **daisyUI usage in PPX-specific files:** none — no `daisy` string and no daisyUI component classes anywhere in the committed overlay (`monorepo/**`, `loculus_values/`, config). The custom components (asides, `OutbreakHintBox`, `CryptoDonationWidget`, `CallToActionButton`, `ToolCard`) use plain Tailwind / bespoke classes.
- **`RestrictedUseWarning` overlay:** renders via Loculus's `ErrorBox`, which the migration moved off the daisyUI `alert` class to Tailwind — so the Pathoplexus restricted-use banner also picks up the fixed text wrapping / styling automatically.

## Verification

- `./sync.sh` fetches the new commit and populates `monorepo/` successfully.
- Loculus side (PR #6604): production build, type-check, and 649/649 unit tests pass; integration tests updated for the new tab roles.

> Draft because the upstream Loculus PR (loculus-project/loculus#6604) isn't merged yet; this points at its branch commit for preview. Re-pin to the squashed commit once it lands on Loculus `main`.

🚀 Preview: https://preview-update-loculus-remove-dai.pathoplexus.org/