### PR TITLE
feat: apply guaranteed QoS for all required/user-facing pods and reduce requested silo/lapis mem for ebola-bdbv and andv

### DIFF
--- a/loculus_values/environment_specific_values/production.yaml
+++ b/loculus_values/environment_specific_values/production.yaml
@@ -79,6 +79,7 @@ enaDeposition:
   enaUniqueSuffix: Pathoplexus
   enaIsBroker: True
 resources:
+# For backend and other required pods, set memory requests = memory limits to ensure guaranteed QoS
   website:
     requests:
       memory: "2Gi"

--- a/loculus_values/environment_specific_values/production.yaml
+++ b/loculus_values/environment_specific_values/production.yaml
@@ -179,6 +179,13 @@ resources:
           cpu: "250m"
         limits:
           memory: "1Gi"
+      ingest:
+        requests:
+          memory: "200Mi"
+          cpu: "50m"
+        limits:
+          cpu: "200m"
+          memory: "10Gi"
     yellow-fever:
       <<: *smallOrganismQueryEngineResources
     ebola-sudan:

--- a/loculus_values/environment_specific_values/production.yaml
+++ b/loculus_values/environment_specific_values/production.yaml
@@ -199,6 +199,32 @@ resources:
           cpu: "250m"
         limits:
           memory: "2Gi"
+    ebola-bdbv:
+      silo:
+        requests:
+          memory: "1Gi"
+          cpu: "250m"
+        limits:
+          memory: "1Gi"
+      lapis:
+        requests:
+          memory: "220Mi"
+          cpu: "250m"
+        limits:
+          memory: "2Gi"
+    andv:
+      silo:
+        requests:
+          memory: "1Gi"
+          cpu: "250m"
+        limits:
+          memory: "1Gi"
+      lapis:
+        requests:
+          memory: "220Mi"
+          cpu: "250m"
+        limits:
+          memory: "2Gi"
 defaultResources:
   requests:
     memory: "200Mi"

--- a/loculus_values/environment_specific_values/production.yaml
+++ b/loculus_values/environment_specific_values/production.yaml
@@ -73,7 +73,7 @@ seqSets:
     hostUrl: "https://pathoplexus.org"
 podPriorityValue: 2000
 disableEnaSubmission: false
-enaDeposition: 
+enaDeposition:
   submitToEnaProduction: true
   enaDbName: Pathoplexus
   enaUniqueSuffix: Pathoplexus
@@ -81,10 +81,10 @@ enaDeposition:
 resources:
   website:
     requests:
-      memory: "1Gi"
+      memory: "2Gi"
       cpu: "1000m"
     limits:
-      memory: "5Gi"
+      memory: "2Gi"
   ena-submission:
     requests:
       memory: "80Mi"
@@ -106,10 +106,10 @@ resources:
       memory: "10Gi"
   keycloak:
     requests:
-      memory: "1500Mi"
+      memory: "2Gi"
       cpu: "1000m"
     limits:
-      memory: "3Gi"
+      memory: "2Gi"
   silo:
     requests:
       memory: "2Gi"
@@ -118,19 +118,19 @@ resources:
       memory: "2Gi"
   lapis:
     requests:
-      memory: "220Mi"
+      memory: "3Gi"
       cpu: "500m"
     limits:
-      memory: "5Gi"
+      memory: "3Gi"
   silo-importer:
     requests:
-      memory: "20Mi"
+      memory: "2Gi"
       cpu: "500m"
     limits:
-      memory: "10Gi"
+      memory: "2Gi"
   backend:
     requests:
-      memory: "1Gi"
+      memory: "3Gi"
       cpu: "1000m"
     limits:
       memory: "3Gi" # Backend requires at least 635741K of memory
@@ -160,7 +160,7 @@ resources:
           cpu: "1000m"
         limits:
           memory: "3Gi"
-    marburg:
+    marburg: &smallOrganismQueryEngineResources
       silo:
         requests:
           memory: "1Gi"
@@ -172,65 +172,27 @@ resources:
           memory: "220Mi"
           cpu: "250m"
         limits:
-          memory: "2Gi"
+          memory: "220Mi"
+      silo-importer:
+        requests:
+          memory: "1Gi"
+          cpu: "250m"
+        limits:
+          memory: "1Gi"
     yellow-fever:
-      silo:
-        requests:
-          memory: "1Gi"
-          cpu: "250m"
-        limits:
-          memory: "1Gi"
-      lapis:
-        requests:
-          memory: "220Mi"
-          cpu: "250m"
-        limits:
-          memory: "2Gi"
+      <<: *smallOrganismQueryEngineResources
     ebola-sudan:
-      silo:
-        requests:
-          memory: "1Gi"
-          cpu: "250m"
-        limits:
-          memory: "1Gi"
-      lapis:
-        requests:
-          memory: "220Mi"
-          cpu: "250m"
-        limits:
-          memory: "2Gi"
+      <<: *smallOrganismQueryEngineResources
     ebola-bdbv:
-      silo:
-        requests:
-          memory: "1Gi"
-          cpu: "250m"
-        limits:
-          memory: "1Gi"
-      lapis:
-        requests:
-          memory: "220Mi"
-          cpu: "250m"
-        limits:
-          memory: "2Gi"
+      <<: *smallOrganismQueryEngineResources
     andv:
-      silo:
-        requests:
-          memory: "1Gi"
-          cpu: "250m"
-        limits:
-          memory: "1Gi"
-      lapis:
-        requests:
-          memory: "220Mi"
-          cpu: "250m"
-        limits:
-          memory: "2Gi"
+      <<: *smallOrganismQueryEngineResources
 defaultResources:
   requests:
     memory: "200Mi"
     cpu: "200m"
   limits:
-    memory: "1Gi"
+    memory: "200Mi"
     cpu: "1000m"
 sequenceFlagging:
   github:

--- a/loculus_values/environment_specific_values/production.yaml
+++ b/loculus_values/environment_specific_values/production.yaml
@@ -181,11 +181,11 @@ resources:
           memory: "1Gi"
       ingest:
         requests:
-          memory: "200Mi"
-          cpu: "50m"
+          memory: "100Mi"
+          cpu: "20m"
         limits:
           cpu: "200m"
-          memory: "10Gi"
+          memory: "1Gi"
     yellow-fever:
       <<: *smallOrganismQueryEngineResources
     ebola-sudan:

--- a/loculus_values/environment_specific_values/staging.yaml
+++ b/loculus_values/environment_specific_values/staging.yaml
@@ -80,7 +80,7 @@ defaultResources:
 resources:
   backend:
     requests:
-      memory: "1Gi"
+      memory: "3Gi"
       cpu: "1000m"
     limits:
       memory: "3Gi" # Backend requires at least 635741K of memory

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -3913,7 +3913,7 @@ resources:
 # For backend and other required pods, set memory requests = memory limits to ensure guaranteed QoS
   ingest:
     requests:
-      memory: "200Mi"
+      memory: "100Mi"
       cpu: "50m"
     limits:
       cpu: "200m"

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -3910,7 +3910,6 @@ taxonomyService:
   taxonomyDbPath: "/data/taxonomy.sqlite" # this is where the init container mounts the database
 
 resources:
-# For backend and other required pods, set memory requests = memory limits to ensure guaranteed QoS
   ingest:
     requests:
       memory: "100Mi"
@@ -3920,7 +3919,7 @@ resources:
       memory: "10Gi"
   backend:
     requests:
-      memory: "3Gi"
+      memory: "640Mi"
       cpu: "100m"
     limits:
       memory: "3Gi" # Backend requires at least 635741K of memory

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -3910,6 +3910,7 @@ taxonomyService:
   taxonomyDbPath: "/data/taxonomy.sqlite" # this is where the init container mounts the database
 
 resources:
+# For backend and other required pods, set memory requests = memory limits to ensure guaranteed QoS
   ingest:
     requests:
       memory: "200Mi"
@@ -3919,7 +3920,7 @@ resources:
       memory: "10Gi"
   backend:
     requests:
-      memory: "640Mi"
+      memory: "3Gi"
       cpu: "100m"
     limits:
       memory: "3Gi" # Backend requires at least 635741K of memory


### PR DESCRIPTION
resolves https://github.com/pathoplexus/pathoplexus/issues/920

andv and ebola-bdbv have only very few sequences, we should provision them similarly to yellow-fever and the other ebolas.

Ingest for small organism requests roughly 400 times more mem and cpu than is required (this reduces mem and cpu for ingest by a factor of 10 for small organisms), silo of andv and ebola-bdbv request 25times more than is required (this reduces silo and lapis by a factor of 2).

looking at https://grafana.pathoplexus.org/d/cfl58hc2l83cwb/requested-resources-vs-used-resources?orgId=1&editPanel=2&from=now-1h&to=now apart from ingest the requested memory was actually quite well aligned with the used memory, sth like a factor of 10more on average

🚀 Preview: Add `preview` label to enable