### PR TITLE
Add history links to governance documents

### DIFF
--- a/monorepo/website/src/pages/about/governance/data-submission.mdx
+++ b/monorepo/website/src/pages/about/governance/data-submission.mdx
@@ -164,3 +164,4 @@ Some cases where this may be permitted:
 
 If you wish to request a consideration of having sequences permanently removed, please contact [submissions@pathoplexus.org](mailto:submissions@pathoplexus.org).
 
+*The history of this document can be found [here](https://github.com/pathoplexus/pathoplexus/commits/main/monorepo/website/src/pages/about/governance/data-submission.mdx).*

--- a/monorepo/website/src/pages/about/governance/eb-guidelines.mdx
+++ b/monorepo/website/src/pages/about/governance/eb-guidelines.mdx
@@ -79,4 +79,4 @@ The Executive Board shall serve as an arbitrator and decision maker when conflic
 
 </div>
 
-
+*The history of this document can be found [here](https://github.com/pathoplexus/pathoplexus/commits/main/monorepo/website/src/pages/about/governance/eb-guidelines.mdx).*

--- a/monorepo/website/src/pages/about/governance/pathoplexus-statutes.mdx
+++ b/monorepo/website/src/pages/about/governance/pathoplexus-statutes.mdx
@@ -157,3 +157,5 @@ Only the assets of the Association are liable for the debts of the Association. 
 These articles of Association were adopted by the constitutive meeting on 12 August 2024 and entered with effect on such date.
 
 The articles of Association were adapted by the extraordinary General Assembly on 25 November 2024 to add the role of the Treasurer.
+
+*The history of this document can be found [here](https://github.com/pathoplexus/pathoplexus/commits/main/monorepo/website/src/pages/about/governance/pathoplexus-statutes.mdx).*

--- a/monorepo/website/src/pages/about/governance/sab-guidelines.mdx
+++ b/monorepo/website/src/pages/about/governance/sab-guidelines.mdx
@@ -109,4 +109,4 @@ Regular meetings of the Scientific Advisory Board are also attended by the Execu
 
 </div></div></div>
 
-
+*The history of this document can be found [here](https://github.com/pathoplexus/pathoplexus/commits/main/monorepo/website/src/pages/about/governance/sab-guidelines.mdx).*

--- a/monorepo/website/src/pages/about/governance/values.mdx
+++ b/monorepo/website/src/pages/about/governance/values.mdx
@@ -134,3 +134,5 @@ Data sharing should prioritize positive outcomes, including but not limited to, 
 </div>
 
 </div>
+
+*The history of this document can be found [here](https://github.com/pathoplexus/pathoplexus/commits/main/monorepo/website/src/pages/about/governance/values.mdx).*

--- a/monorepo/website/src/pages/about/terms-of-use/data-use-terms.mdx
+++ b/monorepo/website/src/pages/about/terms-of-use/data-use-terms.mdx
@@ -178,3 +178,5 @@ For Background Set:
 - Are any of the sequences Restricted Use Data? If so, they should only be included as background sequences if they pass the questions above. If not, they should be included in the Focal set and treated appropriately.
 - How is the Background dataset used? Is the Background data truly playing only a contextualizing role, or have the authors focused on any sequences or countries within the Background set? If so, these sequences need to be part of the Focal Set.
 - What is the geographic and time distribution of the data? Is the Background Set more broadly spread than the focal set? If the Background Set doesn’t seem to substantially differ from the Focal Set, should it be part of the Focal Set?
+
+*The history of this document can be found [here](https://github.com/pathoplexus/pathoplexus/commits/main/monorepo/website/src/pages/about/terms-of-use/data-use-terms.mdx).*

--- a/monorepo/website/src/pages/about/terms-of-use/privacy-policy.mdx
+++ b/monorepo/website/src/pages/about/terms-of-use/privacy-policy.mdx
@@ -117,4 +117,4 @@ You have the right to complain about our processing of Personal Data to a superv
 
 This Privacy Policy was last updated on Tuesday, 27th of February 2024, and is the current and valid version. However, from time to time changes or a revision to this policy may be necessary. If you have any questions or comments about our Privacy Policy or wish to exercise your rights under applicable laws, please contact us using the details provided above.
 
-
+*The history of this document can be found [here](https://github.com/pathoplexus/pathoplexus/commits/main/monorepo/website/src/pages/about/terms-of-use/privacy-policy.mdx).*

--- a/monorepo/website/src/pages/about/terms-of-use/terms-of-service.mdx
+++ b/monorepo/website/src/pages/about/terms-of-use/terms-of-service.mdx
@@ -108,6 +108,6 @@ We will aim to give Users, Submitters, and Curators as much notice as possible i
 
 These Terms and any other Terms governing or relating to Pathoplexus, are governed by the law of Switzerland. In the event of any such dispute or claim in connection with these Terms, you agree to first engage in good faith discussion with us to resolve such a dispute or claim. If it cannot be resolved within sixty (60) days, settlement will be by arbitration under the courts of Switzerland.
 
-
+*The history of this document can be found [here](https://github.com/pathoplexus/pathoplexus/commits/main/monorepo/website/src/pages/about/terms-of-use/terms-of-service.mdx).*
 
 


### PR DESCRIPTION
As discussed in a previous meeting, this adds links to git histories for official Pathoplexus documents.


<img width="829" height="150" alt="image" src="https://github.com/user-attachments/assets/b3180dee-dbcd-4b25-a9af-dd95a809038e" />



🚀 Preview: https://preview-docs-history.pathoplexus.org