### PR TITLE
feat(andv): apply grouping curations

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2361,7 +2361,7 @@ organisms:
         <<: *defaultIngestConfigFile
         taxon_id: 1980456
         calculate_groups_override_json: true
-        grouping_override_url: "https://raw.githubusercontent.com/pathoplexus/curation_data/andv-curations/grouping_override/andv/curated_group_08-06-2026.json"
+        grouping_override_url: "https://pathoplexus.github.io/curation_data/grouping_override/andv/curated_group_08-06-2026.json"
         segment_identification:
           method: "minimizer"
           minimizer_url: "https://pathoplexus.github.io/reference_store/andv/segment-minimizer.json"

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2361,6 +2361,7 @@ organisms:
         <<: *defaultIngestConfigFile
         taxon_id: 1980456
         calculate_groups_override_json: true
+        grouping_override_url: "https://raw.githubusercontent.com/pathoplexus/curation_data/andv-curations/grouping_override/andv/curated_group_08-06-2026.json"
         segment_identification:
           method: "minimizer"
           minimizer_url: "https://pathoplexus.github.io/reference_store/andv/segment-minimizer.json"


### PR DESCRIPTION
Following the steps in https://github.com/pathoplexus/curation_reports/issues/18#issuecomment-4649358765

This PR adds a link to a grouping override file as discussed in the curation issue. The affects of this have been tested on staging. Note that the pending revisions for these sequences need to be deleted before the revoke and regroup cronjob can be run. 

See https://loculus.slack.com/archives/C05G172HL6L/p1780924531650189

🚀 Preview: Add `preview` label to enable