### PR TITLE
feat(config): preprocessing no longer uses `hostNameScientific` and `hostTaxonId` as fallback values - remove them

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1286,7 +1286,6 @@ defaultOrganismConfig: &defaultOrganismConfig
           function: scientific_name_from_id
           inputs:
             hostTaxonId: processed.hostTaxonId
-            hostNameScientific: hostNameScientific
           args:
             taxonomy_service_url: &taxonomy_service_url "http://loculus-taxonomy-service:5000"
       - name: hostNameCommon
@@ -1331,8 +1330,6 @@ defaultOrganismConfig: &defaultOrganismConfig
           function: resolve_host_taxon_id
           inputs:
             host: host
-            hostNameScientific: hostNameScientific
-            hostTaxonId: hostTaxonId
           args:
             taxonomy_service_url: *taxonomy_service_url
       - name: isLabHost


### PR DESCRIPTION
…hostTaxonId` as fallback values and requires `host`, remove these values from the config to prevent invalid and confusing error messages

resolves: https://github.com/pathoplexus/pathoplexus/issues/1024

I created an account on the preview and validated that the message is now clear:
<img width="2494" height="582" alt="image" src="https://github.com/user-attachments/assets/9c8bc06f-0788-4003-9833-364398fbf87e" />
I then confirmed that using host results in valid output:
<img width="2966" height="534" alt="image" src="https://github.com/user-attachments/assets/ecbbd390-3d55-4e78-903b-55e839134f6c" />



🚀 Preview: https://preview-host.pathoplexus.org