### PR TITLE
bump taxonomy db version to 2026-06-01

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -3904,7 +3904,7 @@ defaultResources:
     cpu: "1000m"
 
 taxonomyService:
-  dbVersion: "ncbi_taxonomy_2026-05-01"
+  dbVersion: "ncbi_taxonomy_2026-06-01"
   taxonomyDbPath: "/data/taxonomy.sqlite" # this is where the init container mounts the database
 
 resources:


### PR DESCRIPTION
This PR bumps the NCBI taxonomy database version to `2026-06-01`. This version now includes taxon `1214919` (Hyalomma plumbeum plumbeum), which is a tick species that is annotated as the host for some existing sequences we have. 

By using the latest taxonomy, this `host` will be valid and used to populate host information in the `processed_data` for these sequences the next time we reprocess.

I checked that the using the latest taxonomy does not lead to regressions by, for example, deleting taxa we use (see below).

# Can we safely use latest NCBI taxonomy?

## Get all 'host' values we use (run against staging DB on 2026-06-09):

```sql
SELECT DISTINCT unprocessed_data -> 'metadata' ->> 'host' as host 
FROM public.sequence_entries
WHERE unprocessed_data -> 'metadata' ? 'host';
```

## Then, load into Python


```python
import pandas as pd

all_hosts = pd.read_csv("2026-06-09_all_host_values.csv").dropna()

tax_ids = pd.Series(i for i in all_hosts["host"].values if i.isdigit()).astype(int)
sci_names = pd.Series(i for i in all_hosts["host"].values if not i.isdigit())

tax_ids.shape, sci_names.shape
```




    ((473,), (21,))



## Load the latest NCBI taxonomy (retrieved 2026-06-04)


```python
df_names = pd.read_csv(
    "./tax_download/names.dmp",
    sep=r"\s*\|\s*",
    engine="python",  # need to use Python engine to do regex separator
    header=None,
).rename(columns={0: "tax_id", 1: "name_txt", 3: "name_class"}).astype({"tax_id": "int"}).loc[:, ["tax_id", "name_txt", "name_class"]]

```

## Which `host` values from our DB are missing?

### Taxon ids

Three taxon ids in our DB are not in the latest NCBI taxonomy.
These are also missing from the version we use in prodcution currently, so there's no regression.


```python
tax_ids[~tax_ids.isin(df_names["tax_id"])]
```




    174    3230309
    175    3260218
    205    3507587
    dtype: int64


### Scientific names

The only scientific name that is returned as missing is 'Homo Sapiens' (specific name wrongly capitalised). 
Since our host validation is case-insensitive, this isn't an issue.


```python
sci_names[~sci_names.isin(df_names["name_txt"])]
```




    16    Homo Sapiens
    dtype: str

🚀 Preview: Add `preview` label to enable