### PR TITLE
fix(website): give BTC/ETH currency select room for its dropdown arrow

### DIFF
--- a/monorepo/website/src/components/CryptoDonationWidget.tsx
+++ b/monorepo/website/src/components/CryptoDonationWidget.tsx
@@ -41,7 +41,7 @@ export const CryptoDonationWidget: FC<CryptoDonationWidgetProps> = ({ addresses 
                     id='crypto-select'
                     value={selectedCrypto}
                     onChange={handleCryptoChange}
-                    className='px-2 py-1 text-sm border border-gray-200 rounded-sm focus:outline-hidden focus:ring-1 focus:ring-primary-400'
+                    className='pl-2 pr-8 py-1 text-sm border border-gray-200 rounded-sm focus:outline-hidden focus:ring-1 focus:ring-primary-400'
                 >
                     <option value='btc'>BTC</option>
                     <option value='eth'>ETH</option>


### PR DESCRIPTION
## Problem

The BTC/ETH currency `<select>` in `CryptoDonationWidget` was too narrow, and the native dropdown arrow overlapped the "BTC"/"ETH" option text.

The select used `px-2`, giving only 8px of right padding — not enough to clear the browser's native dropdown arrow (~20px), so the arrow sat on top of the text and the control looked cramped.

## Fix

Change `px-2` → `pl-2 pr-8` on the `<select>`, reserving 32px on the right for the arrow while keeping the 8px left padding. Kept the native select arrow (no `appearance-none`) to keep the change minimal and consistent with default form controls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: https://preview-fix-crypto-currency-selec.pathoplexus.org