### PR TITLE
docs: fix typos across docs pages

### DIFF
--- a/monorepo/website/src/pages/about/faq.mdx
+++ b/monorepo/website/src/pages/about/faq.mdx
@@ -130,7 +130,7 @@ No, you should _not_ submit your data to both INSDC and Pathoplexus, as it may r
 If you submit to INSDC, we will pull your data into Pathoplexus, so there's no need to submit it here!
 If you submit to Pathoplexus, the data will go to INSDC when you specify (and immediately, if you select the data is open), so there's no need to upload it to INSDC yourself - we'll take care of that!
 
-Since we keep a record of all the data we pass onto INSDC, we ensure we don't duplicate it - but we can't do this if users upload to both place separately!
+Since we keep a record of all the data we pass onto INSDC, we ensure we don't duplicate it - but we can't do this if users upload to both places separately!
 </details>
 
 <details>

--- a/monorepo/website/src/pages/about/governance/data-submission.mdx
+++ b/monorepo/website/src/pages/about/governance/data-submission.mdx
@@ -28,7 +28,7 @@ As used in Database Terms of Service, the following terms shall have the followi
 <div class="indent"><div class="indent">
 1.1 The term “User” shall mean everyone who accesses the web service (https://pathoplexus.org) in any form
 
-1.2 The term “Submitter shall mean those who submit data to Pathoplexus 
+1.2 The term “Submitter” shall mean those who submit data to Pathoplexus 
 
 1.3 The Term “Submitting Group” shall mean a group that a Submitter has submitted sequences on behalf of, and has control over all sequences submitted on behalf of that Submitting Group
 
@@ -53,7 +53,7 @@ All data within Pathoplexus must be used ethically, and in accordance with scien
 # 3. Data Processing
 Pathoplexus processes submitted data to validate, harmonize, and standardize the data and maximize utility. After initial submission and processing, data is available as version 1, and subsequent changes are reflected in incremented versions. By default, the latest version of all data is displayed unless another version is explicitly requested
 
-To allow Users maximum flexibility in accessing data that is most useful for them, only data without the minimum required metadata values and sequences that fail to be identified (via seed-matching) as specified pathogen are rejected.
+To allow Users maximum flexibility in accessing data that is most useful for them, only data without the minimum required metadata values and sequences that fail to be identified (via seed-matching) as the specified pathogen are rejected.
 
 Data processing includes measures such as:
 

--- a/monorepo/website/src/pages/about/governance/eb-guidelines.mdx
+++ b/monorepo/website/src/pages/about/governance/eb-guidelines.mdx
@@ -48,7 +48,7 @@ The fundamental purpose of the Executive Board is to exercise their judgment to 
 The Executive Board will review and evaluate the effectiveness of the governance practices under which the Board operates and make changes to these practices as needed.
 
 ## 2.4 To Oversee Social, Ethical, and Governance Matters
-The Executive Board is responsible for providing oversight in considering and reviewing actual and potential matters relating social, ethical and governance within the Pathoplexus database and association.   
+The Executive Board is responsible for providing oversight in considering and reviewing actual and potential matters relating to social, ethical and governance within the Pathoplexus database and association.   
 
 </div> </div></div>
 

--- a/monorepo/website/src/pages/about/governance/sab-guidelines.mdx
+++ b/monorepo/website/src/pages/about/governance/sab-guidelines.mdx
@@ -49,7 +49,7 @@ The size of the Scientific Advisory Board is between 3-8 individuals. The Genera
 
 The Executive Board shall also consider the diversity of the Scientific Advisory Board composition overall with respect to age, disability, gender identity or expression, ethnicity, military veteran status, national origin, race, religion, sexual orientation, and other backgrounds and experiences. The Pathoplexus association is committed to actively seeking to identify such individuals who will contribute to such diversity and to be included in the pool of candidates from which nominees to the Scientific Advisory Board are selected.
 
-Pathoplexus expects that its Scientific Advisory Board as well as members and staff to act ethically. Each Scientific Advisory Board member must disclose any circumstance that could represent a potential conflict of interest to the Executive Board prior to election. Each Scientific Advisory Board member that experiences a change in circumstance during office that could represent a potential conflict of interest should deliver a notice of such to the Committee. 
+Pathoplexus expects its Scientific Advisory Board as well as members and staff to act ethically. Each Scientific Advisory Board member must disclose any circumstance that could represent a potential conflict of interest to the Executive Board prior to election. Each Scientific Advisory Board member that experiences a change in circumstance during office that could represent a potential conflict of interest should deliver a notice of such to the Committee. 
 
 ## 2.2 Scientific Advisory Board Member Independence
 Scientific Advisory Board members are not to be a part of the Pathoplexus association. Indeed, drawing from the diversity of the community is a strength. 
@@ -88,7 +88,7 @@ The Scientific Advisory Board will be available to evaluate and advise upon the 
 
 
 ## 3.4 To provide advice on Social, Ethical and Governance Matters
-The Scientific Advisory Board should provide advice on possible matters, reviewing actual and potential matters relating social, ethical and governance.   
+The Scientific Advisory Board should provide advice on possible matters, reviewing actual and potential matters relating to social, ethical and governance.   
 
 </div></div></div>
 

--- a/monorepo/website/src/pages/about/terms-of-use/data-use-terms.mdx
+++ b/monorepo/website/src/pages/about/terms-of-use/data-use-terms.mdx
@@ -39,7 +39,7 @@ As used in Data Use Terms, the following terms shall have the following meanings
 <div class="indent"><div class="indent">
 1.1 The term “User” shall mean everyone who accesses the web service (https://pathoplexus.org) in any form
 
-1.2 The term “Submitter shall mean those who submit data to Pathoplexus 
+1.2 The term “Submitter” shall mean those who submit data to Pathoplexus 
 
 1.3 The Term “Submitting Group” shall mean a group that a Submitter has submitted sequences on behalf of, and has control over all sequences submitted on behalf of that Submitting Group
 
@@ -97,7 +97,7 @@ Users utilizing data from Pathoplexus in publications and preprints **must** cre
 - The "Focal Set" is defined as sequences that are key to the analysis and resulting conclusions of the manuscript - these sequences cannot be left out or replaced without changing the analysis significantly. 
 - The "Background Set" is defined as sequences that provide context or background, but could be replaced or (partially) removed, without changing the results. In the circumstance where all available data is being used, the entire set may be equivalent to a "Background Set" - see [Using All Data](#43-using-all-data), below.
 
-For more a more detailed description of how to divide data into "Focal" and "Background Sets", see [4.2.3 'Deciding'](#423-deciding-if-restricted-use-data-is-part-of-a-focal-or-background-set), below.  
+For a more detailed description of how to divide data into "Focal" and "Background Sets", see [4.2.3 'Deciding'](#423-deciding-if-restricted-use-data-is-part-of-a-focal-or-background-set), below.  
 
 The requirements for using Restricted-Use data in a Focal or Background Set differ - **please read carefully**. 
 

--- a/monorepo/website/src/pages/about/terms-of-use/terms-of-service.mdx
+++ b/monorepo/website/src/pages/about/terms-of-use/terms-of-service.mdx
@@ -29,7 +29,7 @@ As used in Database Terms of Service, the following terms shall have the followi
 <div class="indent"><div class="indent">
 1.1 The term “User” shall mean everyone who accesses the web service (https://pathoplexus.org) in any form
 
-1.2 The term “Submitter shall mean those who submit data to Pathoplexus 
+1.2 The term “Submitter” shall mean those who submit data to Pathoplexus 
 
 1.3 The term “Curator” shall mean those who have elevated access in order to help detect and correct errors in the data
 

--- a/monorepo/website/src/pages/docs/concepts/accession.mdx
+++ b/monorepo/website/src/pages/docs/concepts/accession.mdx
@@ -8,7 +8,7 @@ Within Pathoplexus, you will encounter two types of accessions: the Pathoplexus 
 
 Pathoplexus accessions are generated for every sequence present in Pathoplexus.
 If a sequence is uploaded directly to Pathoplexus, it will receive a Pathoplexus accession before having an INSDC accession.
-If it is added to Pathoplexus from INSDC, it will have a Pathoplexus accession as well its original INSDC accession.
+If it is added to Pathoplexus from INSDC, it will have a Pathoplexus accession as well as its original INSDC accession.
 
 ## Pathoplexus accessions
 

--- a/monorepo/website/src/pages/docs/how-to/approve-submissions.mdx
+++ b/monorepo/website/src/pages/docs/how-to/approve-submissions.mdx
@@ -23,7 +23,7 @@ You can only approve and release sequences that have yellow or green checkmarks 
 
 You can filter the processed sequences to only show those with warnings, errors, or which passed, to help you decide which actions to take.
 
-If see something you'd like to change, or want to try and resolve a warning, you can [edit the sequence](edit-submissions).
+If you see something you'd like to change, or want to try and resolve a warning, you can [edit the sequence](edit-submissions).
 
 ### Actioning individual sequences
 
@@ -51,7 +51,7 @@ You can also always view your released sequences by going to 'Browse' in the top
     To use the [demo instance](https://demo.pathoplexus.org) instead of the main instance, please replace `backend.pathoplexus.org` with `backend-demo.pathoplexus.org`.
 </InfoBox>
 
-The following API requests all require an authentication token. Please read [Authenticating via API guide](/docs/how-to/authentication-api) for the instructions to obtain the token an include the token in the HTTP header `Authorization: Bearer <authentication token>`.
+The following API requests all require an authentication token. Please read [Authenticating via API guide](/docs/how-to/authentication-api) for the instructions to obtain the token and include the token in the HTTP header `Authorization: Bearer <authentication token>`.
 
 You can retrieve a list of uploaded but not released sequences by sending a GET request to the endpoint:
 
@@ -61,7 +61,7 @@ https://backend.pathoplexus.org/<organism>/get-sequences?groupIdsFilter=<group i
 
 The available values for the organism are: `cchf`, `ebola-sudan`, `ebola-zaire` and `west-nile`. The `sequenceEntries` field of the returned object contains a list of sequences with their corresponding `status`:
 
-- Sequence that are in the status `RECEIVED` have not yet been processed. This should usually happen within a few minutes.
+- Sequences that are in the status `RECEIVED` have not yet been processed. This should usually happen within a few minutes.
 - Sequences that are in the status `IN_PROCESSING` are currently being processed, please wait a few more moments.
 - Sequences that are in the status `HAS_ERRORS` contain errors. To find out details, we recommend going to the review page on the website: you can find it by going to the Submission Portal and clicking on "Review".
 - Sequences that are in the status `AWAITING_APPROVAL` have passed the processing and quality checks and can be approved.

--- a/monorepo/website/src/pages/docs/how-to/generate-seqset.mdx
+++ b/monorepo/website/src/pages/docs/how-to/generate-seqset.mdx
@@ -39,7 +39,7 @@ If you generate a DOI for the SeqSet (see below), you can also share this link.
 You can add a [DOI](https://www.doi.org/the-identifier/what-is-a-doi/) in order to reference the SeqSet more easily, and to allow your SeqSet to be referenced in publications.
 
 **Important**: 
-Note that after generating at DOI, you will not be able to edit that SeqSet directly any longer.
+Note that after generating a DOI, you will not be able to edit that SeqSet directly any longer.
 If you make edits, you will generate a new 'version' of the SeqSet, which will require generating a new DOI. 
 For this reason, we suggest finalizing your list of sequences _before_ generating a DOI.
 

--- a/monorepo/website/src/pages/docs/how-to/report-sequence-issues.mdx
+++ b/monorepo/website/src/pages/docs/how-to/report-sequence-issues.mdx
@@ -52,7 +52,7 @@ However, anyone can comment on and discuss the issue to debate whether the corre
 
 If it is deemed there's not yet sufficient evidence but more information may come, Curators may leave the issue open for further discussion.
 
-However, if Curators determine there that the issue is not supported by sufficient evidence, or that there is unlikely to be enough evidence to support it in the near future, the issue may be closed.
+However, if Curators determine that the issue is not supported by sufficient evidence, or that there is unlikely to be enough evidence to support it in the near future, the issue may be closed.
 
 ## How issues are actioned
 

--- a/monorepo/website/src/pages/news/2025-07-14-july-update.mdx
+++ b/monorepo/website/src/pages/news/2025-07-14-july-update.mdx
@@ -59,7 +59,7 @@ We were thrilled to see Pathoplexus co-founder and Chair of the Executive Board 
 
 ### Past talks:
 
-- Emma Hodcroft spoke about Pathoplexus at at [Dynamics & Evolution of Human Viruses](https://dynamicsevolution.org/event/5/) (6-9 May, Asnières-sur-Oise, France)
+- Emma Hodcroft spoke about Pathoplexus at [Dynamics & Evolution of Human Viruses](https://dynamicsevolution.org/event/5/) (6-9 May, Asnières-sur-Oise, France)
 - Chaoran Chen spoke about Loculus at [Applied Bioinformatics & Public Health Microbiology (ABPHM)](https://coursesandconferences.wellcomeconnectingscience.org/event/applied-bioinformatics-public-health-microbiology-20250521/) (21-23 May, Hinxton, UK)
 - Emma Hodcroft spoke about data sharing with Pathoplexus at the Swiss Pathogen Surveillance Platform (SPSP) annual meeting (10 June, Bern, Switzerland)
 - Pathoplexus was excited to be invited to speak about the importance of enabling fast, federated pathogen data sharing at [d/acc Berlin](https://lemonade.social/e/iumyMgJE), where Emma Hodcroft spoke (11 June, Berlin, Germany - [livestream recording](https://x.com/i/broadcasts/1jMJgkOdMnwJL))


### PR DESCRIPTION
## Summary

Fixes 16 genuine typos found in a sweep of the documentation/content pages (`about`, `governance`, `terms-of-use`, `docs/how-to`, `news`). Content-only — no code or behaviour changes.

### Fixes

| File | Was → Now |
|------|-----------|
| `about/faq.mdx` | "both **place**" → "both **places**" |
| `about/terms-of-use/data-use-terms.mdx` | "For **more a more** detailed" → "For **a more** detailed" |
| `docs/concepts/accession.mdx` | "**as well its**" → "**as well as its**" |
| `docs/how-to/approve-submissions.mdx` | "**If see** something" → "**If you see**"; "token **an include**" → "**and include**"; "**Sequence that are**" → "**Sequences that are**" |
| `docs/how-to/generate-seqset.mdx` | "generating **at DOI**" → "**a DOI**" |
| `docs/how-to/report-sequence-issues.mdx` | "determine **there that**" → "determine **that**" |
| `news/2025-07-14-july-update.mdx` | "Pathoplexus **at at** [Dynamics…]" → "**at**" |
| `about/governance/data-submission.mdx` | missing closing quote: `“Submitter` → `“Submitter”`; "**as specified** pathogen" → "**as the specified** pathogen" |
| `about/governance/eb-guidelines.mdx` | "**relating social**" → "**relating to social**" |
| `about/governance/sab-guidelines.mdx` | "**expects that its** … to act" → "**expects its** … to act"; "**relating social**" → "**relating to social**" |
| `about/terms-of-use/terms-of-service.mdx` | missing closing quote: `“Submitter` → `“Submitter”` |
| `about/terms-of-use/data-use-terms.mdx` | missing closing quote: `“Submitter` → `“Submitter”` |

The `“Submitter` quote fix appears in three files — every sibling defined term ("User", "Curator", "SeqSet") has its closing quote, so this was a copy-paste omission.

### Deliberately left unchanged
- `data-submission.mdx`: "if the Submitting Group **reject** the Revision" — valid British collective-noun agreement (and consistent with the surrounding "They can accept or reject").
- `eb-guidelines.mdx`: "shall be **directly directed**" — awkward but plausibly intentional emphasis; reworded text felt out of scope for a typo PR.
- `news/2025-08-27-…`: "Institute de Pasteur de Dakar" — inside a submitter-provided group-name link, likely as-registered.

British/European spellings were preserved throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable