### PR TITLE
ci: trim preview-url branch name to 25 chars to match ArgoCD (fixes #995)

### DIFF
--- a/.github/workflows/add-preview-url.yml
+++ b/.github/workflows/add-preview-url.yml
@@ -18,10 +18,6 @@ jobs:
             const pr = context.payload.pull_request;
             const hasPreviewLabel = pr.labels.some((label) => label.name === 'preview');
 
-            // Format the branch name exactly as ArgoCD does when generating the preview
-            // deployment, so the URL we write actually resolves. ArgoCD truncates the branch
-            // to 25 characters (matching loculus-project/loculus); using a longer limit here
-            // produced URLs that did not match the real, shorter preview subdomain.
             const previewSubdomain = pr.head.ref
               .substring(0, 25)
               .replace(/[_/.]+/g, '-')

--- a/.github/workflows/add-preview-url.yml
+++ b/.github/workflows/add-preview-url.yml
@@ -18,8 +18,12 @@ jobs:
             const pr = context.payload.pull_request;
             const hasPreviewLabel = pr.labels.some((label) => label.name === 'preview');
 
+            // Format the branch name exactly as ArgoCD does when generating the preview
+            // deployment, so the URL we write actually resolves. ArgoCD truncates the branch
+            // to 25 characters (matching loculus-project/loculus); using a longer limit here
+            // produced URLs that did not match the real, shorter preview subdomain.
             const previewSubdomain = pr.head.ref
-              .substring(0, 55)
+              .substring(0, 25)
               .replace(/[_/.]+/g, '-')
               .replace(/^-+|-+$/g, '')
               .toLowerCase();


### PR DESCRIPTION
## Problem

Closes #995. The **Add Preview URL** workflow (`.github/workflows/add-preview-url.yml`) truncates the branch name to **55** characters when building the preview URL it writes into the PR description:

```js
const previewSubdomain = pr.head.ref
  .substring(0, 55)            // <-- too long
  .replace(/[_/.]+/g, '-')
  .replace(/^-+|-+$/g, '')
  .toLowerCase();
const previewUrl = `https://preview-${previewSubdomain}.pathoplexus.org`;
```

ArgoCD, however, generates the *actual* preview subdomain from a much shorter (25-character) truncation of the branch — the same convention used in `loculus-project/loculus`, whose `add-preview-url.yml` does:

```js
const shortBranchName = branchName.substring(0, 25) ...
// "Format branch name exactly as in ArgoCD"
```

So for long branch names, the URL written to the PR was **longer than the real preview subdomain and didn't resolve**.

## Fix

Align the truncation with ArgoCD / Loculus (`55` → `25`) and add a comment explaining why the limit must match ArgoCD. No other behaviour changes — the `preview-` prefix, sanitisation, and `.pathoplexus.org` domain are unchanged.

## Note for reviewer

I inferred the `25` from Loculus's reference implementation (which the issue cites as correct) because pathoplexus's ArgoCD ApplicationSet / preview generator lives in private cluster infra and isn't in any public repo. **If pathoplexus's ApplicationSet truncates to a different length, please adjust this number to match** — the important thing is that this workflow uses the *same* limit ArgoCD does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable