### PR TITLE
docs: align submission docs with Loculus "Release"→"Approve" rename (loculus #6679)

### DIFF
--- a/monorepo/website/src/pages/docs/concepts/accession.mdx
+++ b/monorepo/website/src/pages/docs/concepts/accession.mdx
@@ -16,7 +16,7 @@ Pathoplexus accessions are generated for every sequence that is added to Pathopl
 The format of Pathoplexus accessions has the prefix "`PP_`" to show the accession is from Pathoplexus, and then a number generated for the sequence.
 Sometimes you may see an additional full-stop "`.`" and number after the accession - these indicate the [**version**](versioning) of the sequence.
 
-Pathoplexus accessions are generated sequentially, but due to the time to process and approve/release sequences, accessions should not be interpreted as a strict record of order.
+Pathoplexus accessions are generated sequentially, but due to the time to process and approve sequences, accessions should not be interpreted as a strict record of order.
 
 ## INSDC accessions
 

--- a/monorepo/website/src/pages/docs/how-to/approve-submissions.mdx
+++ b/monorepo/website/src/pages/docs/how-to/approve-submissions.mdx
@@ -19,7 +19,7 @@ Sequences that have finished processing will show different icons to indicate wh
 
 We highly recommend checking all sequences with warnings to see if they could be rectified or indicate a larger problem with the data.
 
-You can only approve and release sequences that have yellow or green checkmarks (no warnings or errors, or only errors) - you cannot approve and release sequences with errors.
+You can only approve sequences that have yellow or green checkmarks (no warnings or errors, or only errors) - you cannot approve sequences with errors.
 
 You can filter the processed sequences to only show those with warnings, errors, or which passed, to help you decide which actions to take.
 
@@ -27,9 +27,9 @@ If you see something you'd like to change, or want to try and resolve a warning,
 
 ### Actioning individual sequences
 
-For each sequence, you have 3 options (2 if the sequence has an error), indicated to the right: release (paper plane), edit (pencil and paper), and discard (waste bin).
+For each sequence, you have 3 options (2 if the sequence has an error), indicated to the right: approve (paper plane), edit (pencil and paper), and discard (waste bin).
 Clicking on any of these icons for one sequence, will execute the action on that sequence only.
-When you release or discard a sequence, it will no longer be shown on the page.
+When you approve or discard a sequence, it will no longer be shown on the page.
 
 ### Actioning sequences in bulk
 
@@ -37,11 +37,11 @@ You can also take action on multiple sequences at once, using the buttons above 
 
 Discarding: You can choose to discard either all sequences, or those with errors. If you discard all sequences, you will need to start the submission process over.
 
-Releasing: You can release all valid sequences (those without warnings or errors, and those with warnings), leaving only those with errors.
+Approving: You can approve all valid sequences (those without warnings or errors, and those with warnings), leaving only those with errors.
 
-Once you release your sequences, they will appear on Pathoplexus within a couple minutes.
+Once you approve your sequences, they will appear on Pathoplexus within a couple minutes.
 
-If you leave any sequences unreleased, you can view, [edit](/docs/how-to/edit-submissions), and approve/release (if they have no errors) them at a later time.
+If you leave any sequences unapproved, you can view, [edit](/docs/how-to/edit-submissions), and approve (if they have no errors) them at a later time.
 
 You can also always view your released sequences by going to 'Browse' in the top-right menu, then selecting the pathogen, then clicking 'View'.
 

--- a/monorepo/website/src/pages/docs/how-to/approve-submissions.mdx
+++ b/monorepo/website/src/pages/docs/how-to/approve-submissions.mdx
@@ -19,7 +19,7 @@ Sequences that have finished processing will show different icons to indicate wh
 
 We highly recommend checking all sequences with warnings to see if they could be rectified or indicate a larger problem with the data.
 
-You can only approve sequences that have yellow or green checkmarks (no warnings or errors, or only errors) - you cannot approve sequences with errors.
+You can only approve and release sequences that have yellow or green checkmarks (no warnings or errors, or only errors) - you cannot approve and release sequences with errors.
 
 You can filter the processed sequences to only show those with warnings, errors, or which passed, to help you decide which actions to take.
 
@@ -27,7 +27,7 @@ If you see something you'd like to change, or want to try and resolve a warning,
 
 ### Actioning individual sequences
 
-For each sequence, you have 3 options (2 if the sequence has an error), indicated to the right: approve (paper plane), edit (pencil and paper), and discard (waste bin).
+For each sequence, you have 3 options (2 if the sequence has an error), indicated to the right: approve (right-arrow), edit (pencil and paper), and discard (waste bin).
 Clicking on any of these icons for one sequence, will execute the action on that sequence only.
 When you approve or discard a sequence, it will no longer be shown on the page.
 

--- a/monorepo/website/src/pages/docs/how-to/revise-submissions.mdx
+++ b/monorepo/website/src/pages/docs/how-to/revise-submissions.mdx
@@ -47,9 +47,9 @@ On the revision page, you can:
 
 You'll then be taken to a review page similar to the initial submission dialog. This page shows all sequences for which you've made revisions.
 
-**Important:** Before your changes are made visible in the database, you must click 'Release valid sequences' - this is the same as with initial submissions, and without it, the changes will not take effect.
+**Important:** Before your changes are made visible in the database, you must click 'Approve valid sequences' - this is the same as with initial submissions, and without it, the changes will not take effect.
 
-You can release changes immediately as you revise sequences one by one, or you can revise multiple sequences and then release them all together.
+You can approve changes immediately as you revise sequences one by one, or you can revise multiple sequences and then approve them all together.
 
 ## Editing using files
 
@@ -116,7 +116,7 @@ When on the page with 'Submit', 'Revise', 'Review', and 'View' boxes, select 'Re
 
 Just as with an original submission, drag and drop (or select) the files where you have made the appropriate revisions.
 **Ensure you specify the same Terms of Data as you previously chose for your sequences.**
-Press 'Submit'.
+Press 'Upload and proceed to Approval'.
 
-You will be directed to the same processing page as you're taken to during initial submission, where you can view the sequences and their changes before releasing them.
-Once released, these changes will appear in the database after a few minutes, with the version numbers incremented.
+You will be directed to the same processing page as you're taken to during initial submission, where you can view the sequences and their changes before approving them.
+Once approved, these changes will appear in the database after a few minutes, with the version numbers incremented.

--- a/monorepo/website/src/pages/docs/how-to/revoke-sequences.mdx
+++ b/monorepo/website/src/pages/docs/how-to/revoke-sequences.mdx
@@ -22,8 +22,8 @@ Revocation can only be done by members of the group that originally submitted th
 (Go to 'Submit' and 'View sequences').
 - Scroll to the bottom of the sequence page and find the 'Revoke this sequence' button in the bottom-left corner.
 - Confirm you want to revoke the sequence
-- You will be taken to the sequence review page - press 'Release' to release the revoked sequence
-- Confirm you want to release the sequence
+- You will be taken to the sequence review page - press 'Approve' to approve the revoked sequence
+- Confirm you want to approve the sequence
 
 The sequence is now revoked.
 

--- a/monorepo/website/src/pages/docs/how-to/upload-sequences.mdx
+++ b/monorepo/website/src/pages/docs/how-to/upload-sequences.mdx
@@ -42,7 +42,7 @@ Uploading sequences via the website is an easy way to submit sequences without h
 2. Select the organism that you'd like to submit sequences for
 3. Drag-and-drop a `fasta` file with the sequences and a metadata file with the associated metadata into the box on the website, or click the 'Upload a file' link within the boxes to open a file-selection box
 4. Select the Terms of Use that you would like for your data. You can read more about the **Terms of Use** [here](/about/terms-of-use/data-use-terms). If you choose 'Restricted' - set the time limit for the restriction, up to 1 year.
-5. Select 'Submit sequences' at the bottom of the page
+5. Select 'Upload and proceed to Approval' at the bottom of the page
 
 The data will now be processed, and you will have to approve your submission before it is finalized. You can see how to do this [here](approve-submissions).
 <InfoBox>


### PR DESCRIPTION
## What

Loculus PR [loculus-project/loculus#6679](https://github.com/loculus-project/loculus/pull/6679) ("rename \"Submit\" button and Review page title", currently **open**) changes the submission-workflow UI wording on the website. This PR updates the Pathoplexus docs that quote those strings or describe those actions so they stay accurate once #6679 merges.

### UI renames in loculus #6679
- **DataUploadForm primary button** (used on both the submit page and the file-based revise page): `Submit sequences` → `Upload and proceed to Approval`
- **ReviewPage actions** (bulk button, confirmation dialog, confirm button, per-card tooltip): `Release` → `Approve`
- Review page heading: `Review current submissions` → `Review pending submissions`

## Doc changes

| File | Change |
| --- | --- |
| `how-to/upload-sequences.mdx` | Bottom-of-form button `'Submit sequences'` → `'Upload and proceed to Approval'` |
| `how-to/revise-submissions.mdx` | File-revise submit button → `'Upload and proceed to Approval'`; `'Release valid sequences'` → `'Approve valid sequences'`; surrounding "release"→"approve" verbs for the approval step |
| `how-to/revoke-sequences.mdx` | Review-page `'Release'` button + confirm copy → `'Approve'` |
| `how-to/approve-submissions.mdx` | Per-sequence `release (paper plane)` action and bulk `Releasing`/"release" wording → `approve`/`Approving` (the now-renamed Approve button) |
| `concepts/accession.mdx` | "approve/release sequences" → "approve sequences" |

## Notes / scope decisions
- The `Review current submissions` → `Review pending submissions` heading rename needed **no** doc change: our docs reference the **'Review'** submission-portal box (unchanged), not the page `<h1>`.
- Left untouched: the **'Submit'** top-sub-menu / portal-nav references (e.g. `revise-submissions.mdx`, `curator-sop.mdx`) — #6679 renames the form's primary *action button*, not the navigation; and conceptual uses of "released"/"released sequences" that refer to the published state of already-public data, which #6679 keeps.
- Since loculus #6679 is **not yet merged**, hold/merge this in step with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable