### PR TITLE
docs: drop obsolete post-revoke approval step from revoke guide

### DIFF
--- a/monorepo/website/src/pages/docs/how-to/revoke-sequences.mdx
+++ b/monorepo/website/src/pages/docs/how-to/revoke-sequences.mdx
@@ -22,8 +22,6 @@ Revocation can only be done by members of the group that originally submitted th
 (Go to 'Submit' and 'View sequences').
 - Scroll to the bottom of the sequence page and find the 'Revoke this sequence' button in the bottom-left corner.
 - Confirm you want to revoke the sequence
-- You will be taken to the sequence review page - press 'Release' to release the revoked sequence
-- Confirm you want to release the sequence
 
 The sequence is now revoked.
 


### PR DESCRIPTION
## What

Revoking a sequence no longer routes you to the review page to approve/release the revocation as a separate step — confirming the revocation now completes it. This removes the two now-incorrect instructions from the revocation how-to:

> - ~~You will be taken to the sequence review page - press 'Release' to release the revoked sequence~~
> - ~~Confirm you want to release the sequence~~


🤖 Generated with [Claude Code](https://claude.com/claude-code)

🚀 Preview: Add `preview` label to enable