### PR TITLE
Fix OutBreakHintBox due to Tailwind upgrade

### DIFF
--- a/monorepo/website/src/components/asides/OutbreakHintBox.astro
+++ b/monorepo/website/src/components/asides/OutbreakHintBox.astro
@@ -22,10 +22,12 @@ const { title = 'In outbreak settings' } = Astro.props;
 
 <style is:global>
     .outbreak-hint-box a {
-        @apply font-medium text-amber-700 underline;
+        color: var(--color-amber-700);
+        font-weight: 500;
+        text-decoration-line: underline;
     }
 
     .outbreak-hint-box a:hover {
-        @apply text-amber-900;
+        color: var(--color-amber-900);
     }
 </style>


### PR DESCRIPTION
699387d150491e1ff29b86c838814216a13c8d55 is breaking the website build, it seems that the code was not compatible with Tailwind v4 which was merged in the meantime.

See https://tailwindcss.com/docs/compatibility#vue-svelte-and-astro

🚀 Preview: https://preview-fix-website-outbreak-hint.pathoplexus.org