### PR TITLE
Update inaccurate FAQ about submitted Restricted data

### DIFF
--- a/monorepo/website/src/pages/about/faq.mdx
+++ b/monorepo/website/src/pages/about/faq.mdx
@@ -213,7 +213,7 @@ Pathoplexus ingests data from INSDC-member databases (specifically, from [NCBI D
 We do this automatically at regular intervals, but always preserve the link back to the INSDC source.
 You can easily tell if a sequence originated from INSDC if the 'Submitting group' is `Automated Ingest from INSDC/NCBI Virus`.
 
-Users can also submit data to us directly, which we eventually pass on to the INSDC network. All Restricted-Use data is directly submitted.
+Users can also submit data to us directly, which we eventually pass on to the INSDC network. All Open data is directly submitted, and Restricted data will be submitted after the Restricted-Use period lapses and it becomes Open.
 You can easily tell if Open data was submitted to us directly by seeing if the 'Submitting group' is anyone other than `Automated Ingest from INSDC/NCBI Virus`.
 
 </details>


### PR DESCRIPTION
I think this must be a hanger-on from our plan to submit under embargo (which became impossible due to bioprojects not supporting mixed states)

🚀 Preview: Add `preview` label to enable