### PR TITLE
Document SeqSet citation tracking via Crossref

### DIFF
--- a/monorepo/website/src/pages/about/citation.mdx
+++ b/monorepo/website/src/pages/about/citation.mdx
@@ -65,7 +65,7 @@ A [SeqSet](https://pathoplexus.org/docs/how-to/generate-seqset) is sufficient â€
 
 Full instructions are in our documentation: [Generating & using SeqSets](https://pathoplexus.org/docs/how-to/generate-seqset)
 
-**Key point:** For publications and preprints, the DOI must be cited in your **References section** (as you would cite a paper), not just mentioned in the text. This ensures it is indexed by Crossref and linked to your manuscript. Pathoplexus imports these citations from Crossref and lists the citing publications in the 'Citations' section of the SeqSet's page, so citing the DOI properly also gives credit back to the data generators.
+**Key point:** For publications and preprints, the DOI must be cited in your **References section** (as you would cite a paper), not just mentioned in the text. This ensures it is indexed by Crossref and linked to your manuscript. Pathoplexus imports these citations from Crossref and lists the citing publications on the sequence details page, so citing the DOI properly also gives credit back to the data generators.
 
 
 _Questions? Contact us at [help@pathoplexus.org](mailto:help@pathoplexus.org) or consult the full [Data Use Terms](https://pathoplexus.org/about/terms-of-use/data-use-terms)._

--- a/monorepo/website/src/pages/about/citation.mdx
+++ b/monorepo/website/src/pages/about/citation.mdx
@@ -65,7 +65,7 @@ A [SeqSet](https://pathoplexus.org/docs/how-to/generate-seqset) is sufficient â€
 
 Full instructions are in our documentation: [Generating & using SeqSets](https://pathoplexus.org/docs/how-to/generate-seqset)
 
-**Key point:** For publications and preprints, the DOI must be cited in your **References section** (as you would cite a paper), not just mentioned in the text. This ensures it is indexed by CrossRef and linked to your manuscript.
+**Key point:** For publications and preprints, the DOI must be cited in your **References section** (as you would cite a paper), not just mentioned in the text. This ensures it is indexed by Crossref and linked to your manuscript. Pathoplexus imports these citations from Crossref and lists the citing publications in the 'Citations' section of the SeqSet's page, so citing the DOI properly also gives credit back to the data generators.
 
 
 _Questions? Contact us at [help@pathoplexus.org](mailto:help@pathoplexus.org) or consult the full [Data Use Terms](https://pathoplexus.org/about/terms-of-use/data-use-terms)._

--- a/monorepo/website/src/pages/docs/concepts/seqset.mdx
+++ b/monorepo/website/src/pages/docs/concepts/seqset.mdx
@@ -6,7 +6,7 @@ title: "SeqSets"
 SeqSets (pronounced _seek-set_) are collections of sequences indicated by their Pathoplexus accession numbers, which provide unique identifiers that can be used to reference that set of sequences. 
 
 They can also be used to generate [DOIs](https://www.doi.org/the-identifier/what-is-a-doi/), which can be used to reference that collection of sequences.
-This is particularly useful in publications, where putting the DOI into the reference list (like a paper or other cited resource), will allow tracking of which publications sequences are used in.
+This is particularly useful in publications: when a SeqSet's DOI is included in a paper's reference list, Pathoplexus automatically discovers the citation via [Crossref](https://www.crossref.org/) and lists the citing publications on the SeqSet's page. This lets you track which publications the sequences have been used in.
 
 DOIs and SeqSets can also be used to give credit to sequence generators and share the sequences used in any analysis, whether a social media post, blog post, or in personal communications.
 

--- a/monorepo/website/src/pages/docs/concepts/seqset.mdx
+++ b/monorepo/website/src/pages/docs/concepts/seqset.mdx
@@ -6,7 +6,7 @@ title: "SeqSets"
 SeqSets (pronounced _seek-set_) are collections of sequences indicated by their Pathoplexus accession numbers, which provide unique identifiers that can be used to reference that set of sequences. 
 
 They can also be used to generate [DOIs](https://www.doi.org/the-identifier/what-is-a-doi/), which can be used to reference that collection of sequences.
-This is particularly useful in publications: when a SeqSet's DOI is included in a paper's reference list, Pathoplexus automatically discovers the citation via [Crossref](https://www.crossref.org/) and lists the citing publications on the SeqSet's page. This lets you track which publications the sequences have been used in.
+This is particularly useful in publications: when a SeqSet's DOI is included in a paper's reference list, Pathoplexus automatically discovers the citation via [Crossref](https://www.crossref.org/) and lists the citing publications on each sequence's page.
 
 DOIs and SeqSets can also be used to give credit to sequence generators and share the sequences used in any analysis, whether a social media post, blog post, or in personal communications.
 

--- a/monorepo/website/src/pages/docs/how-to/generate-seqset.mdx
+++ b/monorepo/website/src/pages/docs/how-to/generate-seqset.mdx
@@ -8,6 +8,7 @@ order: 50
 - [Creating a SeqSet](#creating-a-seqset)
 - [Sharing a SeqSet](#sharing-a-seqset)
 - [Adding a DOI](#adding-a-doi)
+- [Viewing citations](#viewing-citations)
 - [Editing a SeqSet](#editing-a-seqset)
 - [Exporting a SeqSet](#exporting-a-seqset)
 - [Deleting a SeqSet](#deleting-a-seqset)
@@ -52,6 +53,14 @@ If you edit a SeqSet after generating a DOI, you will need to generate a new DOI
 Thus, it's usually better to wait until you are confident that you have pulled together all the sequences you want to reference, before generating a DOI.
 
 Once you have generated a DOI, you can no longer delete a SeqSet, as DOIs are intended to be persistent. 
+
+## Viewing citations
+
+Once a SeqSet has a DOI, Pathoplexus tracks the publications that cite it. When a paper includes the SeqSet's DOI in its reference list, the citation is registered with [Crossref](https://www.crossref.org/), and Pathoplexus periodically imports these citations from Crossref.
+
+Any publications that cite the SeqSet are shown in the 'Citations' section of the SeqSet page, under 'Cited in'. If no citations have been found yet, this reads 'No citations found.'. When there are more than a few, click 'View all citations' to see the full list.
+
+Because citations are discovered through Crossref, they only appear after the citing publication has been indexed there, so it can take some time for a new citation to show up. This is also why the DOI must be cited in the **References** section of a manuscript (not just mentioned in the text) — only references indexed by Crossref can be tracked.
 
 ## Editing a SeqSet
 


### PR DESCRIPTION
## Summary
This PR adds documentation about Pathoplexus's citation tracking feature for SeqSets with DOIs. It explains how citations are discovered through Crossref and displayed on SeqSet pages.

## Key Changes
- Added new "Viewing citations" section to the SeqSet how-to guide explaining how Pathoplexus tracks and displays citations of SeqSets via Crossref
- Updated the citation guide to clarify that DOIs must be cited in the References section and explain how this enables citation tracking and credit attribution
- Improved the SeqSet concepts documentation to explain the citation discovery workflow and its benefits for tracking sequence usage

## Notable Details
- Clarified that citations only appear after indexing by Crossref, which can take time
- Emphasized that DOIs must be in the References section (not just mentioned in text) to be tracked by Crossref
- Connected the citation tracking feature to credit attribution for data generators

https://claude.ai/code/session_01CYABbntpZT8gWZVuUthVjF

🚀 Preview: Add `preview` label to enable