### PR TITLE
Update default displayName creation

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -3664,7 +3664,6 @@ organisms:
       - <<: *preprocessing
         version:
           - 27
-          - 28
         replicas: 1
         configFile:
           <<: *preprocessingConfigFile

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2612,22 +2612,6 @@ organisms:
           columnWidth: 74
           order: 6
           orderOnDetailsPage: 720
-        - name: lineage
-          displayName: Lineage
-          definition: Lineage assigned by Nextclade, see https://nextstrain.org/fetch/data.clades.nextstrain.org/v3/nextstrain/mpox/all-clades/2026-07-07--14-07-11Z/tree.json?c=lineage for a view of the Nextclade reference tree.
-          isSequenceFilter: true
-          header: "Clade & Lineage"
-          includeInDownloadsByDefault: true
-          noInput: true
-          generateIndex: true
-          autocomplete: true
-          initiallyVisible: false
-          preprocessing:
-            inputs: {input: nextclade.customNodeAttributes.lineage}
-          columnWidth: 64
-          order: 7
-          orderOnDetailsPage: 740
-          lineageSystem: mpox
         - name: outbreakLineage
           displayName: Outbreak & Lineage
           definition: Outbreak & Lineage assigned by Nextclade

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2621,10 +2621,7 @@ organisms:
           noInput: true
           generateIndex: true
           autocomplete: true
-          # should be set to false on next update (after reprocessing complete)
-          # as lineage itself is no longer unambiguous, outbreak is required
-          # otherwise filtering by A.1 includes sequences from 2 outbreaks
-          initiallyVisible: true
+          initiallyVisible: false
           preprocessing:
             inputs: {input: nextclade.customNodeAttributes.lineage}
           columnWidth: 64

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -202,7 +202,7 @@ defaultOrganismConfig: &defaultOrganismConfig
       - &displayNameConfig
         name: displayName
         displayName: Display name
-        definition: "A human-readable label for the sequence record, with the format `{geoLocCountry}/{identifier}/{sampleCollectionDate}`. The identifier is taken from `specimenCollectorSampleId` if set, otherwise `submissionId`. The identifier is taken directly as the provided field, assuming it contains no slashes or spaces, otherwise the `accessionVersion` is used. Missing `geoLocCountry`/`sampleCollectionDate` default to `unknown`."
+        definition: "A human-readable label for the sequence record, with the format `{geoLocCountry}/{identifier}/{sampleCollectionDate}`. The identifier is provided from `specimenCollectorSampleId` if set, otherwise `submissionId`. For sequences ingested from the INSDC, the identifier is taken directly as the provided field, assuming it contains no slashes or spaces, otherwise the `accessionVersion` is used. For other sequences, if the provided field has a display-name format itself (four or three items, separated by slashes), then the identifier is extracted as the second to last item within this. If the identifier cannot be extracted (due to invalid format of the provided field), the `accessionVersion` is used. Missing `geoLocCountry`/`sampleCollectionDate` default to `unknown`."
         preprocessing:
           function: build_display_name
           inputs:
@@ -213,6 +213,13 @@ defaultOrganismConfig: &defaultOrganismConfig
           args:
             order: [geoLocCountry, IDENTIFIER, sampleCollectionDate]
             type: [string, IDENTIFIER, dateRangeString]
+            # regex pattern constraints:
+            # - Cannot start with a slash
+            # - Four or three fields, separated by exactly two or three slashes
+            # - Last field is a date in format YYYY, YYYY-MM, or YYYY-MM-DD
+            # - Identifier is the second to last field (extracted through named capture group)
+            regex_pattern: '^(?:[^/]+/)?[^/]+/(?P<identifier>[^/]+)/\d{4}(?:-\d{2}){0,2}$'
+            human_readable_pattern: "<any>/<any>/<identifier>/<date>"
         noInput: true
       - name: ncbiReleaseDate
         displayName: NCBI release date

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -74,13 +74,9 @@ siloImport:
 pipelineVersionUpgradeCheckIntervalSeconds: 300
 zstdCompressionLevel: 15
 lineageSystemDefinitions:
-  # TODO: remove mpox lineage system after preprocessing with mpoxOutbreakLineage is complete
-  mpox:
-    20: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2025-09-09--12-13-13Z/lineages.yaml
-    25: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2026-07-07--14-07-11Z/lineages.yaml
   mpoxOutbreakLineage:
-    20: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2026-07-07--14-07-11Z/outbreak-lineages.yaml
     25: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2026-07-07--14-07-11Z/outbreak-lineages.yaml
+    26: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2026-07-07--14-07-11Z/outbreak-lineages.yaml
   rsv-a:
     21: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
     22: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
@@ -2686,7 +2682,7 @@ organisms:
         <<: *preprocessing
         replicas: 1
         version:
-          - 20
+          - 25
         configFile:
           <<: *preprocessingConfigFile
           batch_size: 5
@@ -2876,7 +2872,7 @@ organisms:
       - <<: *mpoxPreprocessing
         replicas: 3
         version:
-          - 25
+          - 26
         configFile:
           <<: *preprocessingConfigFile
           batch_size: 10

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -193,17 +193,20 @@ defaultOrganismConfig: &defaultOrganismConfig
           rangeDisplayName: Collection date
           bound: upper
         noInput: true
-      - name: displayName
+      - &displayNameConfig
+        name: displayName
         displayName: Display name
-        definition: A human-readable label for the sequence record, with the format `{geoLocCountry}/{accessionVersion}/{sampleCollectionDate}`.
+        definition: "A human-readable label for the sequence record, with the format `{geoLocCountry}/{identifier}/{sampleCollectionDate}`. The identifier is taken from `specimenCollectorSampleId` if set, otherwise `submissionId`. The identifier is taken directly as the provided field, assuming it contains no slashes or spaces, otherwise the `accessionVersion` is used. Missing `geoLocCountry`/`sampleCollectionDate` default to `unknown`."
         preprocessing:
-          function: concatenate
+          function: build_display_name
           inputs:
             geoLocCountry: geoLocCountry
             sampleCollectionDate: processed.sampleCollectionDate
+            specimenCollectorSampleId: specimenCollectorSampleId
+            submissionId: submissionId
           args:
-            order: [geoLocCountry, ACCESSION_VERSION, sampleCollectionDate]
-            type: [string, ACCESSION_VERSION, dateRangeString]
+            order: [geoLocCountry, IDENTIFIER, sampleCollectionDate]
+            type: [string, IDENTIFIER, dateRangeString]
         noInput: true
       - name: ncbiReleaseDate
         displayName: NCBI release date
@@ -1974,10 +1977,8 @@ organisms:
           example: "Isolate 1"
           desired: true
         # custom displayName construction for Dengue
-        - name: displayName
-          displayName: Display name
+        - <<: *displayNameConfig
           definition: A human-readable label for the sequence record, with the format `{serotype}/{geoLocCountry}/{identifier}/{sampleCollectionDate}`. The identifier is provided from `specimenCollectorSampleId` if set, otherwise `submissionId`. For sequences ingested from the INSDC, the identifier is taken directly as the provided field, assuming it contains no slashes or spaces, otherwise the `accessionVersion` is used. For other sequences, if the provided field has a display-name format itself (four items, separated by three slashes), then the identifier is extracted as the second to last item within this. If the identifier cannot be extracted (due to invalid format of the provided field), the `accessionVersion` is used. Missing `geoLocCountry`/`sampleCollectionDate` default to `unknown`.
-          noInput: true
           preprocessing:
             function: build_display_name
             inputs:
@@ -1995,6 +1996,7 @@ organisms:
               # - Last field is a date in format YYYY, YYYY-MM, or YYYY-MM-DD
               # - Identifier is the second to last field (extracted through named capture group)
               regex_pattern: '^[^/][^/]*/[^/]+/(?P<identifier>[^/]+)/\d{4}(?:-\d{2}){0,2}$'
+              human_readable_pattern: "<any>/<any>/<identifier>/<date>"
         - name: serotype
           displayName: Serotype
           definition: "Which of the antigenically distinct types of dengue virus the sequence was most closely assigned to according to Nextclade."
@@ -3620,6 +3622,16 @@ organisms:
           orderOnDetailsPage: 630
           definition: "MeaNS2 ID."
           guidance: "Add the MeaNS2 ID if sequence has also been uploaded to MeaNS2"
+        - <<: *displayNameConfig
+          definition: A human-readable label for the sequence record, with the format `{geoLocCountry}/{accessionVersion}/{sampleCollectionDate}`.
+          preprocessing:
+            function: concatenate
+            inputs:
+              geoLocCountry: geoLocCountry
+              sampleCollectionDate: processed.sampleCollectionDate
+            args:
+              order: [geoLocCountry, ACCESSION_VERSION, sampleCollectionDate]
+              type: [string, ACCESSION_VERSION, dateRangeString]
       website: 
         <<: *website
         tableColumns:
@@ -3834,10 +3846,8 @@ organisms:
           example: "Isolate 1"
           desired: true
         # custom displayName construction for YFV
-        - name: displayName
-          displayName: Display name
+        - <<: *displayNameConfig
           definition: A human-readable label for the sequence record, with the format `YFV/{geoLocCountry}/{identifier}/{sampleCollectionDate}`. The identifier is provided from `specimenCollectorSampleId` if set, otherwise `submissionId`. For sequences ingested from the INSDC, the identifier is taken directly as the provided field, assuming it contains no slashes or spaces, otherwise the `accessionVersion` is used. For other sequences, if the provided field has a display-name format itself (four items, separated by three slashes), then the identifier is extracted as the second to last item within this. If the identifier cannot be extracted (due to invalid format of the provided field), the `accessionVersion` is used. Missing `geoLocCountry`/`sampleCollectionDate` default to `unknown`.
-          noInput: true
           preprocessing:
             function: build_display_name
             inputs:
@@ -3855,6 +3865,7 @@ organisms:
               # - Last field is a date in format YYYY, YYYY-MM, or YYYY-MM-DD
               # - Identifier is the second to last field (extracted through named capture group)
               regex_pattern: '^[^/][^/]*/[^/]+/(?P<identifier>[^/]+)/\d{4}(?:-\d{2}){0,2}$'
+              human_readable_pattern: "<any>/<any>/<identifier>/<date>"
       website:
         <<: *website
         tableColumns:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -83,16 +83,22 @@ lineageSystemDefinitions:
     25: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2026-07-07--14-07-11Z/outbreak-lineages.yaml
   rsv-a:
     21: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
+    22: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
   rsv-b:
     22: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-b/2025-08-25--09-00-35Z/lineages.yaml
+    23: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-b/2025-08-25--09-00-35Z/lineages.yaml
   hmpv:
     23: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/hmpv/2025-09-09--12-13-13Z/lineages.yaml
+    24: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/hmpv/2025-09-09--12-13-13Z/lineages.yaml
   cchfS:
     23: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/cchf/S/2025-09-24--07-29-03Z/lineages.yaml
+    24: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/cchf/S/2025-09-24--07-29-03Z/lineages.yaml
   marburg:
     24: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/marburg/2025-09-09--12-13-13Z/lineages.yaml
+    25: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/marburg/2025-09-09--12-13-13Z/lineages.yaml
   dengue:
     30: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/dengue/all/2025-09-09--12-13-13Z/lineages.yaml
+    31: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/dengue/all/2025-09-09--12-13-13Z/lineages.yaml
 defaultOrganismConfig: &defaultOrganismConfig
   schema: &schema
     submissionDataTypes: &defaultSubmissionDataTypes
@@ -1677,6 +1683,7 @@ organisms:
         replicas: 1
         version:
           - 29
+          - 30
         configFile:
           <<: *preprocessingConfigFile
           segments:
@@ -1740,6 +1747,7 @@ organisms:
       - <<: *preprocessing
         version:
           - 26
+          - 27
         configFile:
           <<: *preprocessingConfigFile
           segments:
@@ -1846,6 +1854,7 @@ organisms:
         <<: *preprocessing
         version:
           - 5
+          - 6
         configFile: &ebolaBdbvPreprocessingConfigFile
           <<: *preprocessingConfigFile
           segments:
@@ -2238,6 +2247,7 @@ organisms:
       - <<: *preprocessing
         version:
           - 27
+          - 28
         configFile:
           <<: *preprocessingConfigFile
           segments:
@@ -2334,6 +2344,7 @@ organisms:
       - <<: *preprocessing
         version:
           - 6
+          - 7
         configFile:
           <<: *preprocessingConfigFile
           create_embl_file: false
@@ -2485,6 +2496,7 @@ organisms:
       - <<: *preprocessing
         version:
           - 23
+          - 24
         configFile:
           <<: *preprocessingConfigFile
           log_level: DEBUG
@@ -3300,6 +3312,7 @@ organisms:
       - <<: *preprocessing
         version:
           - 21
+          - 22
         replicas: 1
         configFile:
           <<: *preprocessingConfigFile
@@ -3423,6 +3436,7 @@ organisms:
       - <<: *preprocessing
         version:
           - 22
+          - 23
         replicas: 1
         configFile:
           <<: *preprocessingConfigFile
@@ -3536,6 +3550,7 @@ organisms:
         replicas: 1
         version:
           - 23
+          - 24
         configFile:
           <<: *preprocessingConfigFile
           segments:
@@ -3649,6 +3664,7 @@ organisms:
       - <<: *preprocessing
         version:
           - 27
+          - 28
         replicas: 1
         configFile:
           <<: *preprocessingConfigFile
@@ -3745,6 +3761,7 @@ organisms:
       - <<: *preprocessing
         version:
           - 24
+          - 25
         replicas: 1
         configFile:
           <<: *preprocessingConfigFile
@@ -3884,6 +3901,7 @@ organisms:
       - <<: *preprocessing
         version:
           - 29
+          - 30
         configFile:
           <<: *preprocessingConfigFile
           segments:


### PR DESCRIPTION
To be merged when we roll out https://github.com/loculus-project/loculus/pull/6774

The PR incorporates the breaking change introduced in https://github.com/loculus-project/loculus/pull/6774, which now makes it so we need to add a `human_readable_pattern` if we use regex to attempt to parse the identifier field (affecting YFV and DENV)

This PR also updates the default configuration for displayName creation on PPX. By default, the displayName will be generated using `build_display_name`, which attempts to use the `specimenCollectorSampleId` in the displayName (or, if this fails, the`submissionId`, but only for direct submissions). 

Measles still uses the old displayName for now - it requires a custom displayName that we havent configured yet.

We'll need to reprocess all sequences when we roll this out to ensure the new displayName creation is used, so the PR also includes pipeline version bumps (except for measles).

🚀 Preview: https://preview-display-name-update.pathoplexus.org