### PR TITLE
bump dengue pipeline version

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2036,6 +2036,7 @@ organisms:
         <<: *preprocessing
         version:
           - 30
+          - 31
         replicas: 1
         configFile:
           <<: *preprocessingConfigFile


### PR DESCRIPTION
I missed the preprocessing pipeline version bump for dengue here: https://github.com/pathoplexus/pathoplexus/pull/1078

🚀 Preview: Add `preview` label to enable