### PR TITLE
Clean up old pipeline versions

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -75,25 +75,18 @@ pipelineVersionUpgradeCheckIntervalSeconds: 300
 zstdCompressionLevel: 15
 lineageSystemDefinitions:
   mpoxOutbreakLineage:
-    25: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2026-07-07--14-07-11Z/outbreak-lineages.yaml
     26: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2026-07-07--14-07-11Z/outbreak-lineages.yaml
   rsv-a:
-    21: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
     22: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
   rsv-b:
-    22: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-b/2025-08-25--09-00-35Z/lineages.yaml
     23: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-b/2025-08-25--09-00-35Z/lineages.yaml
   hmpv:
-    23: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/hmpv/2025-09-09--12-13-13Z/lineages.yaml
     24: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/hmpv/2025-09-09--12-13-13Z/lineages.yaml
   cchfS:
-    23: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/cchf/S/2025-09-24--07-29-03Z/lineages.yaml
     24: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/cchf/S/2025-09-24--07-29-03Z/lineages.yaml
   marburg:
-    24: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/marburg/2025-09-09--12-13-13Z/lineages.yaml
     25: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/marburg/2025-09-09--12-13-13Z/lineages.yaml
   dengue:
-    30: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/dengue/all/2025-09-09--12-13-13Z/lineages.yaml
     31: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/dengue/all/2025-09-09--12-13-13Z/lineages.yaml
 defaultOrganismConfig: &defaultOrganismConfig
   schema: &schema
@@ -1685,7 +1678,6 @@ organisms:
       - <<: *preprocessing
         replicas: 1
         version:
-          - 29
           - 30
         configFile:
           <<: *preprocessingConfigFile
@@ -1749,7 +1741,6 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 26
           - 27
         configFile:
           <<: *preprocessingConfigFile
@@ -1856,7 +1847,6 @@ organisms:
       - &ebolaBdbvPreprocessing
         <<: *preprocessing
         version:
-          - 5
           - 6
         configFile: &ebolaBdbvPreprocessingConfigFile
           <<: *preprocessingConfigFile
@@ -2035,7 +2025,6 @@ organisms:
       - &denguePreprocessing
         <<: *preprocessing
         version:
-          - 30
           - 31
         replicas: 1
         configFile:
@@ -2250,7 +2239,6 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 27
           - 28
         configFile:
           <<: *preprocessingConfigFile
@@ -2347,7 +2335,6 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 6
           - 7
         configFile:
           <<: *preprocessingConfigFile
@@ -2499,7 +2486,6 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 23
           - 24
         configFile:
           <<: *preprocessingConfigFile
@@ -2679,7 +2665,7 @@ organisms:
         <<: *preprocessing
         replicas: 1
         version:
-          - 25
+          - 26
         configFile:
           <<: *preprocessingConfigFile
           batch_size: 5
@@ -2866,20 +2852,20 @@ organisms:
                   - OPG208
                   - OPG209
                   - OPG210
-      - <<: *mpoxPreprocessing
-        replicas: 3
-        version:
-          - 26
-        configFile:
-          <<: *preprocessingConfigFile
-          batch_size: 10
-          segments:
-            - name: main
-              references:
-              - name: singleReference
-                nextclade_dataset_name: nextstrain/mpox/all-clades
-                nextclade_dataset_tag: 2026-07-07--14-07-11Z
-                genes: *mpoxGenes
+      # - <<: *mpoxPreprocessing
+      #   replicas: 3
+      #   version:
+      #     - 26
+      #   configFile:
+      #     <<: *preprocessingConfigFile
+      #     batch_size: 10
+      #     segments:
+      #       - name: main
+      #         references:
+      #         - name: singleReference
+      #           nextclade_dataset_name: nextstrain/mpox/all-clades
+      #           nextclade_dataset_tag: 2026-07-07--14-07-11Z
+      #           genes: *mpoxGenes
     ingest:
       <<: *ingest
       configFile:
@@ -3311,7 +3297,6 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 21
           - 22
         replicas: 1
         configFile:
@@ -3435,7 +3420,6 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 22
           - 23
         replicas: 1
         configFile:
@@ -3549,7 +3533,6 @@ organisms:
       - <<: *preprocessing
         replicas: 1
         version:
-          - 23
           - 24
         configFile:
           <<: *preprocessingConfigFile
@@ -3759,7 +3742,6 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 24
           - 25
         replicas: 1
         configFile:
@@ -3899,7 +3881,6 @@ organisms:
     preprocessing:
       - <<: *preprocessing
         version:
-          - 29
           - 30
         configFile:
           <<: *preprocessingConfigFile


### PR DESCRIPTION
Noticed we still had old pipeline versions in the config (left over from previous rollout).

I checked that PPX currently uses the new pipeline version for each organisms through the admin dashboard, so this PR removes these old pipeline versions.

🚀 Preview: Add `preview` label to enable