### PR TITLE
Add autocomplete configuration for sequencingInstrument and sequencingAssayType

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1100,6 +1100,8 @@ defaultOrganismConfig: &defaultOrganismConfig
         header: Sequencing
         desired: true
         orderOnDetailsPage: 2080
+        generateIndex: true
+        autocomplete: true
         preprocessing:
           function: process_options
           inputs:
@@ -1216,6 +1218,8 @@ defaultOrganismConfig: &defaultOrganismConfig
         displayName: Sequencing assay type
         header: Sequencing
         orderOnDetailsPage: 2130
+        generateIndex: true
+        autocomplete: true
         preprocessing:
           function: process_options
           inputs:


### PR DESCRIPTION
Follow up to https://github.com/pathoplexus/pathoplexus/pull/1091

In the above PR we restricted inputs to sequencingInstrument and sequencingAssayType metadata fields, but forgot to add configuration to make the search fields on the website autocompletes. This PR just adds that configuration.

🚀 Preview: Add `preview` label to enable