### PR TITLE
feat(config): temporarily revert options list changes - go back to pr…

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -79,8 +79,8 @@ pipelineVersionUpgradeCheckIntervalSeconds: 300
 zstdCompressionLevel: 15
 lineageSystemDefinitions:
   mpoxOutbreakLineage:
+    26: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2026-07-07--14-07-11Z/outbreak-lineages.yaml
     27: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2026-07-07--14-07-11Z/outbreak-lineages.yaml
-    28: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2026-07-07--14-07-11Z/outbreak-lineages.yaml
   rsv-a:
     23: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
   rsv-b:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1088,112 +1088,113 @@ defaultOrganismConfig: &defaultOrganismConfig
       - name: sequencingInstrument
         ontology_id: GENEPIO:0001452
         definition: The model of the sequencing instrument used.
-        guidance: Select the sequencing instrument from the pick list.
+        # guidance: Select the sequencing instrument from the pick list.
+        guidance: "First check if there exists a standardized term: https://www.ebi.ac.uk/ols4/ontologies/obi for your model, if not add your model in free text."
         example: MinION
         displayName: Sequencing instrument
         header: Sequencing
         desired: true
         orderOnDetailsPage: 2080
-        generateIndex: true
-        autocomplete: true
-        preprocessing:
-          function: process_options
-          inputs:
-            input: sequencingInstrument
-        options:
-          # ena-webin-cli -context reads -fields
-          # ena-webin-cli=9.0.3
-          # Last checked: 09.06.2026
-          # Fields listed in INSTRUMENT (excluding `unspecified`)
-          - name: "454 GS"
-          - name: "454 GS 20"
-          - name: "454 GS FLX"
-          - name: "454 GS FLX Titanium"
-          - name: "454 GS FLX+"
-          - name: "454 GS Junior"
-          - name: "AB 310 Genetic Analyzer"
-          - name: "AB 3130 Genetic Analyzer"
-          - name: "AB 3130xL Genetic Analyzer"
-          - name: "AB 3500 Genetic Analyzer"
-          - name: "AB 3500xL Genetic Analyzer"
-          - name: "AB 3730 Genetic Analyzer"
-          - name: "AB 3730xL Genetic Analyzer"
-          - name: "AB 5500 Genetic Analyzer"
-          - name: "AB 5500xl Genetic Analyzer"
-          - name: "AB 5500xl-W Genetic Analysis System"
-          - name: "BGISEQ-50"
-          - name: "BGISEQ-500"
-          - name: "DNBSEQ-G400"
-          - name: "DNBSEQ-G400 FAST"
-          - name: "DNBSEQ-G50"
-          - name: "DNBSEQ-T7"
-          - name: "Element AVITI"
-          - name: "FASTASeq 300"
-          - name: "GENIUS"
-          - name: "GS111"
-          - name: "Genapsys Sequencer"
-          - name: "GenoCare 1600"
-          - name: "GenoLab M"
-          - name: "GridION"
-          - name: "Helicos HeliScope"
-          - name: "HiSeq X Five"
-          - name: "HiSeq X Ten"
-          - name: "Illumina Genome Analyzer"
-          - name: "Illumina Genome Analyzer II"
-          - name: "Illumina Genome Analyzer IIx"
-          - name: "Illumina HiScanSQ"
-          - name: "Illumina HiSeq 1000"
-          - name: "Illumina HiSeq 1500"
-          - name: "Illumina HiSeq 2000"
-          - name: "Illumina HiSeq 2500"
-          - name: "Illumina HiSeq 3000"
-          - name: "Illumina HiSeq 4000"
-          - name: "Illumina HiSeq X"
-          - name: "Illumina MiSeq"
-          - name: "Illumina MiniSeq"
-          - name: "Illumina NovaSeq 6000"
-          - name: "Illumina NovaSeq X"
-          - name: "Illumina iSeq 100"
-          - name: "Ion GeneStudio S5"
-          - name: "Ion GeneStudio S5 Plus"
-          - name: "Ion GeneStudio S5 Prime"
-          - name: "Ion Torrent Genexus"
-          - name: "Ion Torrent PGM"
-          - name: "Ion Torrent Proton"
-          - name: "Ion Torrent S5"
-          - name: "Ion Torrent S5 XL"
-          - name: "MGISEQ-2000RS"
-          - name: "MinION"
-          - name: "NextSeq 1000"
-          - name: "NextSeq 2000"
-          - name: "NextSeq 500"
-          - name: "NextSeq 550"
-          - name: "Onso"
-          - name: "PacBio RS"
-          - name: "PacBio RS II"
-          - name: "PromethION"
-          - name: "Revio"
-          - name: "Sentosa SQ301"
-          - name: "Sequel"
-          - name: "Sequel II"
-          - name: "Sequel IIe"
-          - name: "UG 100"
-          # Fields listed in PLATFORM
-          - name: "ILLUMINA"
-          - name: "PACBIO_SMRT"
-          - name: "OXFORD_NANOPORE"
-          - name: "BGISEQ"
-          - name: "LS454"
-          - name: "ION_TORRENT"
-          - name: "CAPILLARY"
-          - name: "DNBSEQ"
-          - name: "ELEMENT"
-          - name: "ULTIMA"
-          - name: "VELA_DIAGNOSTICS"
-          - name: "GENAPSYS"
-          - name: "GENEMIND"
-          - name: "TAPESTRI"
-          - name: "AVITI"
+        # generateIndex: true
+        # autocomplete: true
+        # preprocessing:
+        #   function: process_options
+        #   inputs:
+        #     input: sequencingInstrument
+        # options:
+        #   # ena-webin-cli -context reads -fields
+        #   # ena-webin-cli=9.0.3
+        #   # Last checked: 09.06.2026
+        #   # Fields listed in INSTRUMENT (excluding `unspecified`)
+        #   - name: "454 GS"
+        #   - name: "454 GS 20"
+        #   - name: "454 GS FLX"
+        #   - name: "454 GS FLX Titanium"
+        #   - name: "454 GS FLX+"
+        #   - name: "454 GS Junior"
+        #   - name: "AB 310 Genetic Analyzer"
+        #   - name: "AB 3130 Genetic Analyzer"
+        #   - name: "AB 3130xL Genetic Analyzer"
+        #   - name: "AB 3500 Genetic Analyzer"
+        #   - name: "AB 3500xL Genetic Analyzer"
+        #   - name: "AB 3730 Genetic Analyzer"
+        #   - name: "AB 3730xL Genetic Analyzer"
+        #   - name: "AB 5500 Genetic Analyzer"
+        #   - name: "AB 5500xl Genetic Analyzer"
+        #   - name: "AB 5500xl-W Genetic Analysis System"
+        #   - name: "BGISEQ-50"
+        #   - name: "BGISEQ-500"
+        #   - name: "DNBSEQ-G400"
+        #   - name: "DNBSEQ-G400 FAST"
+        #   - name: "DNBSEQ-G50"
+        #   - name: "DNBSEQ-T7"
+        #   - name: "Element AVITI"
+        #   - name: "FASTASeq 300"
+        #   - name: "GENIUS"
+        #   - name: "GS111"
+        #   - name: "Genapsys Sequencer"
+        #   - name: "GenoCare 1600"
+        #   - name: "GenoLab M"
+        #   - name: "GridION"
+        #   - name: "Helicos HeliScope"
+        #   - name: "HiSeq X Five"
+        #   - name: "HiSeq X Ten"
+        #   - name: "Illumina Genome Analyzer"
+        #   - name: "Illumina Genome Analyzer II"
+        #   - name: "Illumina Genome Analyzer IIx"
+        #   - name: "Illumina HiScanSQ"
+        #   - name: "Illumina HiSeq 1000"
+        #   - name: "Illumina HiSeq 1500"
+        #   - name: "Illumina HiSeq 2000"
+        #   - name: "Illumina HiSeq 2500"
+        #   - name: "Illumina HiSeq 3000"
+        #   - name: "Illumina HiSeq 4000"
+        #   - name: "Illumina HiSeq X"
+        #   - name: "Illumina MiSeq"
+        #   - name: "Illumina MiniSeq"
+        #   - name: "Illumina NovaSeq 6000"
+        #   - name: "Illumina NovaSeq X"
+        #   - name: "Illumina iSeq 100"
+        #   - name: "Ion GeneStudio S5"
+        #   - name: "Ion GeneStudio S5 Plus"
+        #   - name: "Ion GeneStudio S5 Prime"
+        #   - name: "Ion Torrent Genexus"
+        #   - name: "Ion Torrent PGM"
+        #   - name: "Ion Torrent Proton"
+        #   - name: "Ion Torrent S5"
+        #   - name: "Ion Torrent S5 XL"
+        #   - name: "MGISEQ-2000RS"
+        #   - name: "MinION"
+        #   - name: "NextSeq 1000"
+        #   - name: "NextSeq 2000"
+        #   - name: "NextSeq 500"
+        #   - name: "NextSeq 550"
+        #   - name: "Onso"
+        #   - name: "PacBio RS"
+        #   - name: "PacBio RS II"
+        #   - name: "PromethION"
+        #   - name: "Revio"
+        #   - name: "Sentosa SQ301"
+        #   - name: "Sequel"
+        #   - name: "Sequel II"
+        #   - name: "Sequel IIe"
+        #   - name: "UG 100"
+        #   # Fields listed in PLATFORM
+        #   - name: "ILLUMINA"
+        #   - name: "PACBIO_SMRT"
+        #   - name: "OXFORD_NANOPORE"
+        #   - name: "BGISEQ"
+        #   - name: "LS454"
+        #   - name: "ION_TORRENT"
+        #   - name: "CAPILLARY"
+        #   - name: "DNBSEQ"
+        #   - name: "ELEMENT"
+        #   - name: "ULTIMA"
+        #   - name: "VELA_DIAGNOSTICS"
+        #   - name: "GENAPSYS"
+        #   - name: "GENEMIND"
+        #   - name: "TAPESTRI"
+        #   - name: "AVITI"
       - name: sequencingProtocol
         ontology_id: GENEPIO:0001454
         definition: The protocol used to generate the sequence.
@@ -1206,64 +1207,65 @@ defaultOrganismConfig: &defaultOrganismConfig
       - name: sequencingAssayType
         ontology_id: GENEPIO:0100997
         definition: The overarching sequencing technique that was used to determine the sequence of a biomaterial, also called library strategy in the INSDC.
-        guidance: Select the sequencing technology from the pick list.
+        # guidance: Select the sequencing technology from the pick list.
+        guidance: "First check if there exists a standardized term: https://www.ebi.ac.uk/ols4/ontologies/obi for your assay, if not add your methodology in free text."
         desired: true
         example: WGS
         displayName: Sequencing assay type
         header: Sequencing
         orderOnDetailsPage: 2130
-        generateIndex: true
-        autocomplete: true
-        preprocessing:
-          function: process_options
-          inputs:
-            input: sequencingAssayType
-        options:
-          # ena-webin-cli -context reads -fields
-          # ena-webin-cli=9.0.3
-          # Last checked: 09.06.2026
-          # Fields listed in LIBRARY_STRATEGY
-          - name: "WGS"
-          - name: "WGA"
-          - name: "WXS"
-          - name: "RNA-Seq"
-          - name: "ssRNA-seq"
-          - name: "snRNA-seq"
-          - name: "miRNA-Seq"
-          - name: "ncRNA-Seq"
-          - name: "FL-cDNA"
-          - name: "EST"
-          - name: "Hi-C"
-          - name: "ATAC-seq"
-          - name: "WCS"
-          - name: "RAD-Seq"
-          - name: "CLONE"
-          - name: "POOLCLONE"
-          - name: "AMPLICON"
-          - name: "CLONEEND"
-          - name: "FINISHING"
-          - name: "ChIP-Seq"
-          - name: "MNase-Seq"
-          - name: "DNase-Hypersensitivity"
-          - name: "Bisulfite-Seq"
-          - name: "CTS"
-          - name: "MRE-Seq"
-          - name: "MeDIP-Seq"
-          - name: "MBD-Seq"
-          - name: "Tn-Seq"
-          - name: "VALIDATION"
-          - name: "FAIRE-seq"
-          - name: "SELEX"
-          - name: "RIP-Seq"
-          - name: "ChIA-PET"
-          - name: "Synthetic-Long-Read"
-          - name: "Targeted-Capture"
-          - name: "Tethered Chromatin Conformation Capture"
-          - name: "NOMe-seq"
-          - name: "ChM-Seq"
-          - name: "GBS"
-          - name: "Ribo-seq"
-          - name: "OTHER"
+        # generateIndex: true
+        # autocomplete: true
+        # preprocessing:
+        #   function: process_options
+        #   inputs:
+        #     input: sequencingAssayType
+        # options:
+        #   # ena-webin-cli -context reads -fields
+        #   # ena-webin-cli=9.0.3
+        #   # Last checked: 09.06.2026
+        #   # Fields listed in LIBRARY_STRATEGY
+        #   - name: "WGS"
+        #   - name: "WGA"
+        #   - name: "WXS"
+        #   - name: "RNA-Seq"
+        #   - name: "ssRNA-seq"
+        #   - name: "snRNA-seq"
+        #   - name: "miRNA-Seq"
+        #   - name: "ncRNA-Seq"
+        #   - name: "FL-cDNA"
+        #   - name: "EST"
+        #   - name: "Hi-C"
+        #   - name: "ATAC-seq"
+        #   - name: "WCS"
+        #   - name: "RAD-Seq"
+        #   - name: "CLONE"
+        #   - name: "POOLCLONE"
+        #   - name: "AMPLICON"
+        #   - name: "CLONEEND"
+        #   - name: "FINISHING"
+        #   - name: "ChIP-Seq"
+        #   - name: "MNase-Seq"
+        #   - name: "DNase-Hypersensitivity"
+        #   - name: "Bisulfite-Seq"
+        #   - name: "CTS"
+        #   - name: "MRE-Seq"
+        #   - name: "MeDIP-Seq"
+        #   - name: "MBD-Seq"
+        #   - name: "Tn-Seq"
+        #   - name: "VALIDATION"
+        #   - name: "FAIRE-seq"
+        #   - name: "SELEX"
+        #   - name: "RIP-Seq"
+        #   - name: "ChIA-PET"
+        #   - name: "Synthetic-Long-Read"
+        #   - name: "Targeted-Capture"
+        #   - name: "Tethered Chromatin Conformation Capture"
+        #   - name: "NOMe-seq"
+        #   - name: "ChM-Seq"
+        #   - name: "GBS"
+        #   - name: "Ribo-seq"
+        #   - name: "OTHER"
       - name: sequencedByOrganization
         ontology_id: GENEPIO:0100416
         definition: The name of the agency, organization or institution responsible for sequencing the isolate's genome.
@@ -2826,7 +2828,7 @@ organisms:
         <<: *preprocessing
         replicas: 1
         version:
-          - 27
+          - 26
         configFile:
           <<: *preprocessingConfigFile
           batch_size: 5
@@ -3013,20 +3015,20 @@ organisms:
                   - OPG208
                   - OPG209
                   - OPG210
-      - <<: *mpoxPreprocessing
-        replicas: 3
-        version:
-          - 28
-        configFile:
-          <<: *preprocessingConfigFile
-          batch_size: 10
-          segments:
-            - name: main
-              references:
-              - name: singleReference
-                nextclade_dataset_name: nextstrain/mpox/all-clades
-                nextclade_dataset_tag: 2026-07-07--14-07-11Z
-                genes: *mpoxGenes
+      # - <<: *mpoxPreprocessing
+      #   replicas: 3
+      #   version:
+      #     - 27
+      #   configFile:
+      #     <<: *preprocessingConfigFile
+      #     batch_size: 10
+      #     segments:
+      #       - name: main
+      #         references:
+      #         - name: singleReference
+      #           nextclade_dataset_name: nextstrain/mpox/all-clades
+      #           nextclade_dataset_tag: 2026-07-07--14-07-11Z
+      #           genes: *mpoxGenes
     ingest:
       <<: *ingest
       configFile:


### PR DESCRIPTION
Current state:

- all organisms (except mpox) have been versioned bumped and are on the latest version - code has been merged to remove previous versions but this is not live on prod
- mpox has been bumped to v27 without alignments, v26 still exists (v26 has alignments and is without restricted options) [I attempted to bump mpox to v28 on staging but this did not bump because some sequences did not align - this has now been rolled back]

🚀 Preview: Add `preview` label to enable