### PR TITLE
config: clean up old mpox pipeline

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -79,7 +79,6 @@ pipelineVersionUpgradeCheckIntervalSeconds: 300
 zstdCompressionLevel: 15
 lineageSystemDefinitions:
   mpoxOutbreakLineage:
-    27: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2026-07-07--14-07-11Z/outbreak-lineages.yaml
     28: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2026-07-07--14-07-11Z/outbreak-lineages.yaml
   rsv-a:
     23: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
@@ -2826,7 +2825,7 @@ organisms:
         <<: *preprocessing
         replicas: 1
         version:
-          - 27
+          - 28
         configFile:
           <<: *preprocessingConfigFile
           batch_size: 5
@@ -3013,20 +3012,20 @@ organisms:
                   - OPG208
                   - OPG209
                   - OPG210
-      - <<: *mpoxPreprocessing
-        replicas: 3
-        version:
-          - 28
-        configFile:
-          <<: *preprocessingConfigFile
-          batch_size: 10
-          segments:
-            - name: main
-              references:
-              - name: singleReference
-                nextclade_dataset_name: nextstrain/mpox/all-clades
-                nextclade_dataset_tag: 2026-07-07--14-07-11Z
-                genes: *mpoxGenes
+      # - <<: *mpoxPreprocessing
+      #   replicas: 3
+      #   version:
+      #     - 28
+      #   configFile:
+      #     <<: *preprocessingConfigFile
+      #     batch_size: 10
+      #     segments:
+      #       - name: main
+      #         references:
+      #         - name: singleReference
+      #           nextclade_dataset_name: nextstrain/mpox/all-clades
+      #           nextclade_dataset_tag: 2026-07-07--14-07-11Z
+      #           genes: *mpoxGenes
     ingest:
       <<: *ingest
       configFile:


### PR DESCRIPTION
Cleaning up config of version 27 of the mpox processing pipeline

🚀 Preview: Add `preview` label to enable