### PR TITLE
feat: Remove unused yaml anchors

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2818,17 +2818,15 @@ organisms:
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
     preprocessing:
-      - &mpoxPreprocessing
-        <<: *preprocessing
+      - <<: *preprocessing
         replicas: 1
         version:
           - 28
         configFile:
           <<: *preprocessingConfigFile
-          batch_size: 5
+          batch_size: 10
           segments:
-            - &mpoxDataset
-              name: main
+            - name: main
               references:
               - name: singleReference
                 nextclade_dataset_name: nextstrain/mpox/all-clades

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2486,28 +2486,29 @@ organisms:
         configFile:
           <<: *preprocessingConfigFile
           create_embl_file: false
-          taxon_id: 1980456
           scientific_name: "Andes Virus"
           molecule_type: "genomic RNA"
           alignment_requirement: ANY
           segment_classification_method: minimizer
           minimizer_url: "https://pathoplexus.github.io/reference_store/andv/segment-minimizer.json"
-          nextclade_dataset_tag: "2026-05-29--13-46-38Z"
           segments:
             - name: L
               references:
                 - name: singleReference
                   nextclade_dataset_name: nextstrain/orthohantavirus/andv/l
+                  nextclade_dataset_tag: "2026-05-29--13-46-38Z"
                   genes: [RdRp]
             - name: M
               references:
                 - name: singleReference
                   nextclade_dataset_name: nextstrain/orthohantavirus/andv/m
+                  nextclade_dataset_tag: "2026-05-29--13-46-38Z"
                   genes: [GPC, Gn, Gc]
             - name: S
               references:
                 - name: singleReference
                   nextclade_dataset_name: nextstrain/orthohantavirus/andv/s
+                  nextclade_dataset_tag: "2026-05-29--13-46-38Z"
                   genes: ["N", NSs]
     ingest:
       <<: *ingest

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -79,7 +79,6 @@ pipelineVersionUpgradeCheckIntervalSeconds: 300
 zstdCompressionLevel: 15
 lineageSystemDefinitions:
   mpoxOutbreakLineage:
-    27: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2026-07-07--14-07-11Z/outbreak-lineages.yaml
     28: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/mpox/2026-07-07--14-07-11Z/outbreak-lineages.yaml
   rsv-a:
     23: https://pathoplexus.github.io/silo-lineage-hierarchy-definitions/definitions/rsv-a/2025-08-25--09-00-35Z/lineages.yaml
@@ -2814,17 +2813,15 @@ organisms:
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
     preprocessing:
-      - &mpoxPreprocessing
-        <<: *preprocessing
+      - <<: *preprocessing
         replicas: 1
         version:
-          - 27
+          - 28
         configFile:
           <<: *preprocessingConfigFile
-          batch_size: 5
+          batch_size: 10
           segments:
-            - &mpoxDataset
-              name: main
+            - name: main
               references:
               - name: singleReference
                 nextclade_dataset_name: nextstrain/mpox/all-clades
@@ -3005,20 +3002,6 @@ organisms:
                   - OPG208
                   - OPG209
                   - OPG210
-      - <<: *mpoxPreprocessing
-        replicas: 3
-        version:
-          - 28
-        configFile:
-          <<: *preprocessingConfigFile
-          batch_size: 10
-          segments:
-            - name: main
-              references:
-              - name: singleReference
-                nextclade_dataset_name: nextstrain/mpox/all-clades
-                nextclade_dataset_tag: 2026-07-07--14-07-11Z
-                genes: *mpoxGenes
     ingest:
       <<: *ingest
       configFile:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1995,18 +1995,15 @@ organisms:
           - length
           - outbreak
     preprocessing:
-      - &ebolaBdbvPreprocessing
-        <<: *preprocessing
+      - <<: *preprocessing
         version:
           - 7
-        configFile: &ebolaBdbvPreprocessingConfigFile
+        configFile:
           <<: *preprocessingConfigFile
           segments:
-            - &ebolaBdbvPreprocessingSegment
-              name: main
+            - name: main
               references:
-                - &ebolaBdbvPreprocessingReference
-                  name: "singleReference"
+                - name: "singleReference"
                   nextclade_dataset_name: nextstrain/orthoebolavirus/bdbv
                   nextclade_dataset_tag: "2026-05-18--20-09-34Z"
                   genes: [NP, VP35, VP40, GP, GP_003, VP30, VP24, L]
@@ -2173,8 +2170,7 @@ organisms:
         defaultOrder: descending
         referenceIdentifierField: serotype
     preprocessing:
-      - &denguePreprocessing
-        <<: *preprocessing
+      - <<: *preprocessing
         version:
           - 32
         replicas: 1
@@ -2388,8 +2384,7 @@ organisms:
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
     preprocessing:
-      - &westNilePreprocessing
-        <<: *preprocessing
+      - <<: *preprocessing
         version:
           - 29
         configFile:
@@ -2826,7 +2821,7 @@ organisms:
               - name: singleReference
                 nextclade_dataset_name: nextstrain/mpox/all-clades
                 nextclade_dataset_tag: 2026-07-07--14-07-11Z
-                genes: &mpoxGenes
+                genes:
                   - OPG001
                   - OPG002
                   - OPG003
@@ -3431,8 +3426,7 @@ organisms:
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
     preprocessing:
-      - &rsvAPreprocessing
-        <<: *preprocessing
+      - <<: *preprocessing
         version:
           - 23
         replicas: 1
@@ -3555,8 +3549,7 @@ organisms:
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
     preprocessing:
-      - &rsvBPreprocessing
-        <<: *preprocessing
+      - <<: *preprocessing
         version:
           - 24
         replicas: 1
@@ -3668,8 +3661,7 @@ organisms:
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
     preprocessing:
-      - &hmpvPreprocessing
-        <<: *preprocessing
+      - <<: *preprocessing
         replicas: 1
         version:
           - 25
@@ -3783,8 +3775,7 @@ organisms:
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
     preprocessing:
-      - &measlesPreprocessing
-        <<: *preprocessing
+      - <<: *preprocessing
         version:
           - 28
         replicas: 1

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2203,10 +2203,6 @@ organisms:
                   nextclade_dataset_name: community/v-gen-lab/dengue/denv4
                   nextclade_dataset_tag: 2025-09-09--12-13-13Z
                   genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
-      # - <<: *denguePreprocessing
-      #   replicas: 3
-      #   version:
-      #     - 32
     ingest:
       <<: *ingest
       configFile:
@@ -2393,7 +2389,7 @@ organisms:
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
     preprocessing:
-      - &yellowFeverPreprocessing
+      - &westNilePreprocessing
         <<: *preprocessing
         version:
           - 29
@@ -2406,10 +2402,6 @@ organisms:
                 nextclade_dataset_name: nextstrain/wnv/all-lineages
                 nextclade_dataset_tag: "2026-03-04--12-40-26Z"
                 genes: [capsid, prM, env, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
-      # - <<: *yellowFeverPreprocessing
-      #   replicas: 2
-      #   version:
-      #     - 29
     ingest:
       <<: *ingest
       configFile:
@@ -3456,7 +3448,7 @@ organisms:
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
     preprocessing:
-      - &rsvaPreprocessing
+      - &rsvAPreprocessing
         <<: *preprocessing
         version:
           - 23
@@ -3474,10 +3466,6 @@ organisms:
                   - rsv-a
           require_nextclade_sort_match: true
           minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
-      # - <<: *rsvaPreprocessing
-      #   replicas: 3
-      #   version:
-      #     - 23
     ingest:
       <<: *ingest
       configFile:
@@ -3584,7 +3572,7 @@ organisms:
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
     preprocessing:
-      - &rsvbPreprocessing
+      - &rsvBPreprocessing
         <<: *preprocessing
         version:
           - 24
@@ -3602,10 +3590,6 @@ organisms:
                 genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
           require_nextclade_sort_match: true
           minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
-      # - <<: *rsvbPreprocessing
-      #   replicas: 3
-      #   version:
-      #     - 24
     ingest:
       <<: *ingest
       configFile:
@@ -3715,10 +3699,6 @@ organisms:
                 nextclade_dataset_name: "nextstrain/hmpv/all-clades/NC_039199"
                 nextclade_dataset_tag: "2025-04-25--12-24-24Z"
                 genes: [ "F", "G", "L", "M", "N", "M2-1", "M2-2", "P", "SH" ]
-      # - <<: *hmpvPreprocessing
-      #   replicas: 2
-      #   version:
-      #     - 25
     ingest:
       <<: *ingest
       configFile:
@@ -3834,10 +3814,6 @@ organisms:
                 nextclade_dataset_name: "nextstrain/measles/genome/WHO-2012"
                 nextclade_dataset_tag: "2025-08-11--19-06-01Z"
                 genes: [ "C", "F", "H", "L", "M", "N", "P", "V" ]
-      # - <<: *measlesPreprocessing
-      #   replicas: 3
-      #   version:
-      #     - 28
     ingest:
       <<: *ingest
       configFile:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2216,10 +2216,6 @@ organisms:
                   nextclade_dataset_name: community/v-gen-lab/dengue/denv4
                   nextclade_dataset_tag: 2025-09-09--12-13-13Z
                   genes: [C, prM, E, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
-      # - <<: *denguePreprocessing
-      #   replicas: 3
-      #   version:
-      #     - 32
     ingest:
       <<: *ingest
       configFile:
@@ -2406,7 +2402,7 @@ organisms:
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
     preprocessing:
-      - &yellowFeverPreprocessing
+      - &westNilePreprocessing
         <<: *preprocessing
         version:
           - 29
@@ -2419,10 +2415,6 @@ organisms:
                 nextclade_dataset_name: nextstrain/wnv/all-lineages
                 nextclade_dataset_tag: "2026-03-04--12-40-26Z"
                 genes: [capsid, prM, env, NS1, NS2A, NS2B, NS3, NS4A, 2K, NS4B, NS5]
-      # - <<: *yellowFeverPreprocessing
-      #   replicas: 2
-      #   version:
-      #     - 29
     ingest:
       <<: *ingest
       configFile:
@@ -3460,7 +3452,7 @@ organisms:
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
     preprocessing:
-      - &rsvaPreprocessing
+      - &rsvAPreprocessing
         <<: *preprocessing
         version:
           - 23
@@ -3478,10 +3470,6 @@ organisms:
                   - rsv-a
           require_nextclade_sort_match: true
           minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
-      # - <<: *rsvaPreprocessing
-      #   replicas: 3
-      #   version:
-      #     - 23
     ingest:
       <<: *ingest
       configFile:
@@ -3588,7 +3576,7 @@ organisms:
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
     preprocessing:
-      - &rsvbPreprocessing
+      - &rsvBPreprocessing
         <<: *preprocessing
         version:
           - 24
@@ -3606,10 +3594,6 @@ organisms:
                 genes: [ "F", "G", "L", "M", "M2-1", "M2-2", "N", "NS1", "NS2", "P", "SH" ]
           require_nextclade_sort_match: true
           minimizer_url: "https://loculus-project.github.io/nextclade-sort-minimizers/data/rsv/minimizer.json"
-      # - <<: *rsvbPreprocessing
-      #   replicas: 3
-      #   version:
-      #     - 24
     ingest:
       <<: *ingest
       configFile:
@@ -3719,10 +3703,6 @@ organisms:
                 nextclade_dataset_name: "nextstrain/hmpv/all-clades/NC_039199"
                 nextclade_dataset_tag: "2025-04-25--12-24-24Z"
                 genes: [ "F", "G", "L", "M", "N", "M2-1", "M2-2", "P", "SH" ]
-      # - <<: *hmpvPreprocessing
-      #   replicas: 2
-      #   version:
-      #     - 25
     ingest:
       <<: *ingest
       configFile:
@@ -3838,10 +3818,6 @@ organisms:
                 nextclade_dataset_name: "nextstrain/measles/genome/WHO-2012"
                 nextclade_dataset_tag: "2025-08-11--19-06-01Z"
                 genes: [ "C", "F", "H", "L", "M", "N", "P", "V" ]
-      # - <<: *measlesPreprocessing
-      #   replicas: 3
-      #   version:
-      #     - 28
     ingest:
       <<: *ingest
       configFile:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1995,18 +1995,15 @@ organisms:
           - length
           - outbreak
     preprocessing:
-      - &ebolaBdbvPreprocessing
-        <<: *preprocessing
+      - <<: *preprocessing
         version:
           - 7
-        configFile: &ebolaBdbvPreprocessingConfigFile
+        configFile:
           <<: *preprocessingConfigFile
           segments:
-            - &ebolaBdbvPreprocessingSegment
-              name: main
+            - name: main
               references:
-                - &ebolaBdbvPreprocessingReference
-                  name: "singleReference"
+                - name: "singleReference"
                   nextclade_dataset_name: nextstrain/orthoebolavirus/bdbv
                   nextclade_dataset_tag: "2026-05-18--20-09-34Z"
                   genes: [NP, VP35, VP40, GP, GP_003, VP30, VP24, L]
@@ -2187,8 +2184,7 @@ organisms:
         defaultOrder: descending
         referenceIdentifierField: serotype
     preprocessing:
-      - &denguePreprocessing
-        <<: *preprocessing
+      - <<: *preprocessing
         version:
           - 32
         replicas: 1
@@ -2402,8 +2398,7 @@ organisms:
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
     preprocessing:
-      - &westNilePreprocessing
-        <<: *preprocessing
+      - <<: *preprocessing
         version:
           - 29
         configFile:
@@ -2831,7 +2826,7 @@ organisms:
               - name: singleReference
                 nextclade_dataset_name: nextstrain/mpox/all-clades
                 nextclade_dataset_tag: 2026-07-07--14-07-11Z
-                genes: &mpoxGenes
+                genes:
                   - OPG001
                   - OPG002
                   - OPG003
@@ -3450,8 +3445,7 @@ organisms:
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
     preprocessing:
-      - &rsvAPreprocessing
-        <<: *preprocessing
+      - <<: *preprocessing
         version:
           - 23
         replicas: 1
@@ -3574,8 +3568,7 @@ organisms:
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
     preprocessing:
-      - &rsvBPreprocessing
-        <<: *preprocessing
+      - <<: *preprocessing
         version:
           - 24
         replicas: 1
@@ -3687,8 +3680,7 @@ organisms:
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
     preprocessing:
-      - &hmpvPreprocessing
-        <<: *preprocessing
+      - <<: *preprocessing
         replicas: 1
         version:
           - 25
@@ -3802,8 +3794,7 @@ organisms:
         defaultOrderBy: sampleCollectionDate
         defaultOrder: descending
     preprocessing:
-      - &measlesPreprocessing
-        <<: *preprocessing
+      - <<: *preprocessing
         version:
           - 28
         replicas: 1


### PR DESCRIPTION
~- Fix ANDV config to correclty pin dataset tag (and remove unused taxon id)~ completed in https://github.com/pathoplexus/pathoplexus/pull/1108
- Remove unused anchors (#1101 will make bump/prune easy programatically in future so no need to keep anchors around if unused, script will auto-add anchors when helpful)

🚀 Preview: Add `preview` label to enable