### PR TITLE
fix(andv): move nextclade dataset tag to correct level in prepro

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2513,28 +2513,29 @@ organisms:
         configFile:
           <<: *preprocessingConfigFile
           create_embl_file: false
-          taxon_id: 1980456
           scientific_name: "Andes Virus"
           molecule_type: "genomic RNA"
           alignment_requirement: ANY
           segment_classification_method: minimizer
           minimizer_url: "https://pathoplexus.github.io/reference_store/andv/segment-minimizer.json"
-          nextclade_dataset_tag: "2026-05-29--13-46-38Z"
           segments:
             - name: L
               references:
                 - name: singleReference
                   nextclade_dataset_name: nextstrain/orthohantavirus/andv/l
+                  nextclade_dataset_tag: "2026-05-29--13-46-38Z"
                   genes: [RdRp]
             - name: M
               references:
                 - name: singleReference
                   nextclade_dataset_name: nextstrain/orthohantavirus/andv/m
+                  nextclade_dataset_tag: "2026-05-29--13-46-38Z"
                   genes: [GPC, Gn, Gc]
             - name: S
               references:
                 - name: singleReference
                   nextclade_dataset_name: nextstrain/orthohantavirus/andv/s
+                  nextclade_dataset_tag: "2026-05-29--13-46-38Z"
                   genes: ["N", NSs]
     ingest:
       <<: *ingest


### PR DESCRIPTION
While working on a values.yaml linter for prepro config it came up that we pin dataset wrongly for andv. The taxonid is also unused (verified with Anya and reading source code over at loculus-project/loculus).

The deleted lines had no effect whatsoever - the pin did but until 6 months ago. So we weren't pinning - which is fine as there's no new dataset but this fixes it moving forward.