### PR TITLE
Narrow Yellow fever clade column to 76px

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -4017,6 +4017,7 @@ organisms:
           preprocessing:
             inputs: {input: nextclade.clade}
           order: 5
+          columnWidth: 76
           orderOnDetailsPage: 740
         - name: specimenCollectorSampleId
           displayName: Isolate name


### PR DESCRIPTION
The YFV clade field had no columnWidth set, so it fell back to the Loculus default of 130px which is wider than we need, wasting horizontal space. Most other clade/lineage fields use custom (narrower) width.

🚀 Preview: Add `preview` label to enable