### PR TITLE
Add missing Taxonium link-outs

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2087,6 +2087,18 @@ organisms:
           category: "Other"
           maxNumberOfRecommendedEntries: 45000
           url: "https://mapoplexus.genomium.org/?url={{[metadata]}}"
+        - name: "Place on viral UShER tree (DENV-1)"
+          maxNumberOfRecommendedEntries: 2500
+          url: "https://www.taxonium.org/build?mode=no_genbank&startingTreeUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/dengue_virus_type_1/optimized.pb.gz}}&refGbffUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/dengue_virus_type_1/treetime_rerooted_NC_001477.1.gbff}}&refFastaUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/dengue_virus_type_1/treetime_rerooted_NC_001477.1.fa}}&originalMetadataUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/dengue_virus_type_1/metadata.tsv.gz}}&fastaUrl={{[unalignedNucleotideSequences:DENV-1|fasta]}}&metadataUrl={{[metadata]}}&organism={{dengue virus type 1}}"
+        - name: "Place on viral UShER tree (DENV-2)"
+          maxNumberOfRecommendedEntries: 2500
+          url: "https://www.taxonium.org/build?mode=no_genbank&startingTreeUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/dengue_virus_type_2/optimized.pb.gz}}&refGbffUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/dengue_virus_type_2/treetime_rerooted_NC_001474.2.gbff}}&refFastaUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/dengue_virus_type_2/treetime_rerooted_NC_001474.2.fa}}&originalMetadataUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/dengue_virus_type_2/metadata.tsv.gz}}&fastaUrl={{[unalignedNucleotideSequences:DENV-2|fasta]}}&metadataUrl={{[metadata]}}&organism={{dengue virus type 2}}"
+        - name: "Place on viral UShER tree (DENV-3)"
+          maxNumberOfRecommendedEntries: 2500
+          url: "https://www.taxonium.org/build?mode=no_genbank&startingTreeUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/dengue_virus_type_3/optimized.pb.gz}}&refGbffUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/dengue_virus_type_3/treetime_rerooted_NC_001475.2.gbff}}&refFastaUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/dengue_virus_type_3/treetime_rerooted_NC_001475.2.fa}}&originalMetadataUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/dengue_virus_type_3/metadata.tsv.gz}}&fastaUrl={{[unalignedNucleotideSequences:DENV-3|fasta]}}&metadataUrl={{[metadata]}}&organism={{dengue virus type 3}}"
+        - name: "Place on viral UShER tree (DENV-4)"
+          maxNumberOfRecommendedEntries: 2500
+          url: "https://www.taxonium.org/build?mode=no_genbank&startingTreeUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/dengue_virus_type_4/optimized.pb.gz}}&refGbffUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/dengue_virus_type_4/treetime_rerooted_NC_002640.1.gbff}}&refFastaUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/dengue_virus_type_4/treetime_rerooted_NC_002640.1.fa}}&originalMetadataUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/dengue_virus_type_4/metadata.tsv.gz}}&fastaUrl={{[unalignedNucleotideSequences:DENV-4|fasta]}}&metadataUrl={{[metadata]}}&organism={{dengue virus type 4}}"
       # adding custom description of submissionId to show on website
       extraInputFields:
         - name: id
@@ -2491,6 +2503,10 @@ organisms:
           category: "Other"
           maxNumberOfRecommendedEntries: 45000
           url: "https://mapoplexus.genomium.org/?url={{[metadata]}}"
+        - name: "Place on viral UShER tree (M)"
+          category: "Viral UShER"
+          maxNumberOfRecommendedEntries: 5000
+          url: "https://www.taxonium.org/build?mode=no_genbank&startingTreeUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Orthohantavirus_andesense_M/optimized.pb.gz}}&refGbffUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Orthohantavirus_andesense_M/treetime_rerooted_NC_003467.2.gbff}}&refFastaUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Orthohantavirus_andesense_M/treetime_rerooted_NC_003467.2.fa}}&originalMetadataUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Orthohantavirus_andesense_M/metadata.tsv.gz}}&fastaUrl={{[unalignedNucleotideSequences:M|fasta]}}&metadataUrl={{[metadata]}}&organism={{Orthohantavirus andesense M segment}}"
       website:
         <<: *website
         tableColumns:
@@ -2624,6 +2640,18 @@ organisms:
           category: "Other"
           maxNumberOfRecommendedEntries: 45000
           url: "https://mapoplexus.genomium.org/?url={{[metadata]}}"
+        - name: "Place on viral UShER tree (L)"
+          category: "Viral UShER"
+          maxNumberOfRecommendedEntries: 2000
+          url: "https://www.taxonium.org/build?mode=no_genbank&startingTreeUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Orthonairovirus_haemorrhagiae_L/optimized.pb.gz}}&refGbffUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Orthonairovirus_haemorrhagiae_L/treetime_rerooted_NC_005301.3.gbff}}&refFastaUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Orthonairovirus_haemorrhagiae_L/treetime_rerooted_NC_005301.3.fa}}&originalMetadataUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Orthonairovirus_haemorrhagiae_L/metadata.tsv.gz}}&fastaUrl={{[unalignedNucleotideSequences:L|fasta]}}&metadataUrl={{[metadata]}}&organism={{Orthonairovirus haemorrhagiae L segment}}"
+        - name: "Place on viral UShER tree (M)"
+          category: "Viral UShER"
+          maxNumberOfRecommendedEntries: 5000
+          url: "https://www.taxonium.org/build?mode=no_genbank&startingTreeUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Orthonairovirus_haemorrhagiae_M/optimized.pb.gz}}&refGbffUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Orthonairovirus_haemorrhagiae_M/treetime_rerooted_NC_005300.2.gbff}}&refFastaUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Orthonairovirus_haemorrhagiae_M/treetime_rerooted_NC_005300.2.fa}}&originalMetadataUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Orthonairovirus_haemorrhagiae_M/metadata.tsv.gz}}&fastaUrl={{[unalignedNucleotideSequences:M|fasta]}}&metadataUrl={{[metadata]}}&organism={{Orthonairovirus haemorrhagiae M segment}}"
+        - name: "Place on viral UShER tree (S)"
+          category: "Viral UShER"
+          maxNumberOfRecommendedEntries: 10000
+          url: "https://www.taxonium.org/build?mode=no_genbank&startingTreeUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Orthonairovirus_haemorrhagiae_S/optimized.pb.gz}}&refGbffUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Orthonairovirus_haemorrhagiae_S/treetime_rerooted_NC_005302.1.gbff}}&refFastaUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Orthonairovirus_haemorrhagiae_S/treetime_rerooted_NC_005302.1.fa}}&originalMetadataUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Orthonairovirus_haemorrhagiae_S/metadata.tsv.gz}}&fastaUrl={{[unalignedNucleotideSequences:S|fasta]}}&metadataUrl={{[metadata]}}&organism={{Orthonairovirus haemorrhagiae S segment}}"
       metadataAdd:
         - name: lineage_S
           displayName: "Segment S Lineage"


### PR DESCRIPTION
## Summary

- add viral UShER/Taxonium placement links for dengue serotypes 1–4
- add a placement link for the Andes virus M segment
- add placement links for the CCHF L, M, and S segments
- select the matching sequence/reference or segment in each Pathoplexus download placeholder

## Why

Matching trees and reference assets are now published in the viral UShER tree catalogue, but these Pathoplexus organisms did not expose them through Link Outs. This lets users send selected sequences directly to Taxonium for placement and visualization.

Bundibugyo Ebola remains excluded because there is no matching published viral UShER tree.

## Validation

- parsed `loculus_values/values.yaml` successfully with YAML aliases enabled
- verified all 32 newly referenced tree, reference FASTA/GenBank, and metadata URLs return HTTP 200
- ran `git diff --check`

🚀 Preview: Add `preview` label to enable