### PR TITLE
feat(actions): Claude pr reviews

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -2,7 +2,7 @@ name: Claude Code Review
 
 on:
   pull_request:
-    types: [ready_for_review, reopened]
+    types: [opened, ready_for_review, reopened]
 
 jobs:
   review-with-tracking:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -1,0 +1,75 @@
+name: Claude Code Review
+
+on:
+  pull_request:
+    types: [ready_for_review, reopened]
+
+jobs:
+  review-with-tracking:
+    if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      id-token: write
+      issues: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+
+      - name: PR Review with Progress Tracking
+        uses: anthropics/claude-code-action@v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+
+          # Enable progress tracking
+          track_progress: true
+
+          model: claude-opus-4-5-20251101
+
+          # Your custom review instructions
+          prompt: |
+            REPO: ${{ github.repository }}
+            PR NUMBER: ${{ github.event.pull_request.number }}
+
+            Perform a comprehensive code review with the following focus areas:
+
+            1. **Code Quality**
+               - Clean code principles and best practices
+               - Proper error handling and edge cases
+               - Code readability and maintainability
+
+            2. **Security**
+               - Check for potential security vulnerabilities
+               - Validate input sanitization
+               - Review authentication/authorization logic
+
+            3. **Performance**
+               - Identify potential performance bottlenecks
+               - Review database queries for efficiency
+               - Check for memory leaks or resource issues
+
+            4. **Testing**
+               - Verify adequate test coverage
+               - Review test quality and edge cases
+               - Check for missing test scenarios
+
+            5. **Documentation**
+               - Ensure code is properly documented
+               - Verify README updates for new features
+               - Check API documentation accuracy
+
+            Provide detailed feedback using inline comments for specific issues.
+            Use top-level comments for general observations or praise.
+
+            Generally if you have mentioned something in an inline comment you do not need 
+            to mention it again in the overall review. The overall review should be brief
+            with most points made as inline comments. Keep language simple and to the point.
+
+            Do not add inline comments that are simply praise - inline comments should be
+            actionable.
+
+          claude_args: |
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -27,7 +27,7 @@ jobs:
           # Enable progress tracking
           track_progress: true
 
-          model: claude-opus-4-5-20251101
+          model: claude-opus-5
 
           # Your custom review instructions
           prompt: |


### PR DESCRIPTION
I basically copied over [Loculus' workflow file](https://github.com/loculus-project/loculus/blob/main/.github/workflows/claude-code-review.yml). This should work if we add a `CLAUDE_CODE_OAUTH_TOKEN` to this repository's secrets.

The one tweak I made is adding 'opened' to the array of pull request types that the PR is run on. As far as I understand this makes it so the review also runs on PRs that are opened immedately as 'ready for review', instead of only when a PR is opened as draft and then changed to 'ready for review'. Is this something we actually want (maybe also on Loculus)? If not, I will get rid of it.

🚀 Preview: Add `preview` label to enable