### PR TITLE
Fix model annotation in claude code review action

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -26,9 +26,7 @@ jobs:
 
           # Enable progress tracking
           track_progress: true
-
-          model: claude-opus-5
-
+          
           # Your custom review instructions
           prompt: |
             REPO: ${{ github.repository }}
@@ -73,3 +71,4 @@ jobs:
 
           claude_args: |
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*)"
+            --model opus


### PR DESCRIPTION
It was set in the wrong place causing:

```
Warning: Unexpected input(s) 'model', valid inputs are ['trigger_phrase', 'assignee_trigger', 'label_trigger', 'base_branch', 'branch_prefix', 'branch_name_template', 'allowed_bots', 'allowed_non_write_users', 'include_comments_by_actor', 'exclude_comments_by_actor', 'prompt', 'settings', 'anthropic_api_key', 'claude_code_oauth_token', 'anthropic_federation_rule_id', 'anthropic_organization_id', 'anthropic_service_account_id', 'anthropic_workspace_id', 'anthropic_oidc_audience', 'github_token', 'use_bedrock', 'use_vertex', 'use_foundry', 'claude_args', 'additional_permissions', 'use_sticky_comment', 'classify_inline_comments', 'use_commit_signing', 'ssh_signing_key', 'bot_id', 'bot_name', 'track_progress', 'include_fix_links', 'path_to_claude_code_executable', 'path_to_bun_executable', 'display_report', 'show_full_output', 'plugins', 'plugin_marketplaces']
Run anthropics/claude-code-action@v1
```

🚀 Preview: Add `preview` label to enable