### PR TITLE
Update URL in DEPLOYMENT_PROCEDURE.md

### DIFF
--- a/DEPLOYMENT_PROCEDURE.md
+++ b/DEPLOYMENT_PROCEDURE.md
@@ -24,7 +24,7 @@ Once you have a new release candidate on `main`, you can point the staging serve
 
 The easiest way to do this is with the GitHub action "Create PR to bump staging to latest" in the `loculus_deployments` repository: https://github.com/pathoplexus/loculus_deployments/actions
 
-A little after the PR is merged, changes will be reflected at https://demo.pathoplexus.org. You should also check the health of the application in ArgoCD.
+A little after the PR is merged, changes will be reflected at https://staging.pathoplexus.org. You should also check the health of the application in ArgoCD.
 
 ### Promoting a new version from staging to production
 


### PR DESCRIPTION
From context, it seemed to me that this URL should point to staging, rather than demo

🚀 Preview: Add `preview` label to enable