### PR TITLE
Adding zika to list of organisms in regression tests

### DIFF
--- a/data-integrity-tests/regression-testing/Snakefile
+++ b/data-integrity-tests/regression-testing/Snakefile
@@ -31,6 +31,7 @@ rule all:
                 "hmpv",
                 "measles",
                 "yellow-fever",
+                "zika",
             ],
             difftype=["seq", "meta"],
         ),


### PR DESCRIPTION
Zika needs to be included in the regression tests

🚀 Preview: Add `preview` label to enable