### PR TITLE
fix(ingest): apply the shared ingest config to dengue and marburg

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -3943,7 +3943,6 @@ organisms:
       configFile:
         <<: *defaultIngestConfigFile
         taxon_id: 3052505
-        subsample_fraction: 1
     enaDeposition:
       singleReference:
         configFile:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -3940,6 +3940,7 @@ organisms:
                 nextclade_dataset_tag: "2025-09-09--12-13-13Z"
                 genes: [GP, L, NP, VP24, VP30, VP35, VP40]
     ingest:
+      <<: *ingest
       configFile:
         <<: *defaultIngestConfigFile
         taxon_id: 3052505

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -3940,7 +3940,6 @@ organisms:
                 nextclade_dataset_tag: "2025-09-09--12-13-13Z"
                 genes: [GP, L, NP, VP24, VP30, VP35, VP40]
     ingest:
-      image: ghcr.io/loculus-project/ingest
       configFile:
         <<: *defaultIngestConfigFile
         taxon_id: 3052505

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2223,6 +2223,7 @@ organisms:
     ingest:
       <<: *ingest
       configFile:
+        <<: *defaultIngestConfigFile
         taxon_id: 3052464
     enaDeposition:
       DENV-1:
@@ -3941,6 +3942,7 @@ organisms:
     ingest:
       image: ghcr.io/loculus-project/ingest
       configFile:
+        <<: *defaultIngestConfigFile
         taxon_id: 3052505
         subsample_fraction: 1
     enaDeposition:


### PR DESCRIPTION
Dengue and marburg have never received the shared ingest settings that every other organism gets. They are missing `muted_hashes_url` and `time_between_approve_requests_seconds`.

The cause is that a YAML merge key does not merge recursively. `<<: *ingest` brings in `image` and `configFile`, but an organism that then writes its own `configFile:` replaces the anchor's `configFile` outright instead of extending it. Thirteen organisms avoid this by merging the inner map a level down with `<<: *defaultIngestConfigFile`; dengue and marburg never did.

**What this changes at deploy time.** Dengue and marburg start muting curated hashes and start using the 600 second interval between approve requests. That is a real behaviour change for those two organisms, not a no-op cleanup, so it is worth deciding deliberately rather than waving through — if hash muting should stay off for either of them, the better fix is to merge the anchor and override the single key rather than leave the whole map disconnected.