### PR TITLE
Set the ingest batch size to 1000

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -3943,7 +3943,6 @@ organisms:
       configFile:
         <<: *defaultIngestConfigFile
         taxon_id: 3052505
-        subsample_fraction: 1
     enaDeposition:
       singleReference:
         configFile:

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1772,6 +1772,7 @@ defaultOrganismConfig: &defaultOrganismConfig
     configFile: &defaultIngestConfigFile
       time_between_approve_requests_seconds: 600
       muted_hashes_url: "https://pathoplexus.github.io/curation_data/muted_hashes/muted_hashes.tsv"
+      batch_chunk_size: 1000
 organisms:
   ebola-zaire:
     <<: *defaultOrganismConfig

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -3940,6 +3940,7 @@ organisms:
                 nextclade_dataset_tag: "2025-09-09--12-13-13Z"
                 genes: [GP, L, NP, VP24, VP30, VP35, VP40]
     ingest:
+      <<: *ingest
       configFile:
         <<: *defaultIngestConfigFile
         taxon_id: 3052505

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -3940,7 +3940,6 @@ organisms:
                 nextclade_dataset_tag: "2025-09-09--12-13-13Z"
                 genes: [GP, L, NP, VP24, VP30, VP35, VP40]
     ingest:
-      image: ghcr.io/loculus-project/ingest
       configFile:
         <<: *defaultIngestConfigFile
         taxon_id: 3052505

--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -2223,6 +2223,7 @@ organisms:
     ingest:
       <<: *ingest
       configFile:
+        <<: *defaultIngestConfigFile
         taxon_id: 3052464
     enaDeposition:
       DENV-1:
@@ -3941,6 +3942,7 @@ organisms:
     ingest:
       image: ghcr.io/loculus-project/ingest
       configFile:
+        <<: *defaultIngestConfigFile
         taxon_id: 3052505
         subsample_fraction: 1
     enaDeposition:


### PR DESCRIPTION
Depends on #1123

Reduce ingest's batch size for submissions to backend from 10k to 1k to avoid timeouts (these happen frequently when all ingests run at the same time, overwhelming the backend). 1k should avoid syncs getting stuck on previews. There's no real downside to smaller bathes.