### PR TITLE
Set resources for raw-reads-processing

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -4365,3 +4365,9 @@ resources:
       cpu: "100m"
     limits:
       memory: "3Gi" # Backend requires at least 635741K of memory
+  raw-reads-processing:
+    requests:
+      memory: "8Gi" # deacon loads the whole panhuman index into memory (~3.3Gi on disk, ~4.8Gi peak while loading)
+      cpu: "50m"
+    limits:
+      memory: "8Gi"


### PR DESCRIPTION
Pathoplexus sets no resources for `raw-reads-processing`, so the pod falls back to `defaultResources` — a **1Gi memory limit** on every environment, and a 1000m CPU cap.

That is not enough to start. The service runs deacon for host depletion, and deacon loads the whole panhuman index into memory rather than mapping it: roughly 3.3Gi on disk, peaking near 4.8Gi while it deserialises. The pod would be OOM-killed before serving a request, and nothing in the values would hint at why.

The values here mirror what loculus uses for this service on its preview servers (`kubernetes/loculus/values_preview_server.yaml`): memory request equal to the limit, since the index is resident for the pod's whole life and there is no point letting it be evicted, and **no CPU limit** — loculus removed that deliberately in loculus-project/loculus#7169 because capping it cost about five minutes and caused flakes. Inheriting `defaultResources` would silently reimpose exactly that cap.

**This changes nothing yet.** `disableRawReadsProcessingService` still defaults to `true` and this branch does not set it to `false`, so the deployment is not rendered at all and the key sits unused. That is the point — the sizing is easy to get wrong later and hard to diagnose when you do, so it is better recorded now than discovered as an OOM loop after the service is switched on.

**What to decide:**

- The CPU request of `50m` is copied from loculus's preview server, which is not a production workload. It is only a scheduling floor and there is no limit above it, so the pod can still burst — but if Pathoplexus production expects contention, a higher request would be the way to guarantee it a share.
- Leaving CPU unlimited makes this pod Burstable, not Guaranteed. If Pathoplexus wants the guaranteed-QoS treatment that #1014 applies to user-facing pods, that needs a CPU limit equal to the request, which contradicts the upstream choice above. Worth settling before the service is enabled rather than after.

Put in the base `loculus_values/values.yaml` rather than the environment overlays because the requirement comes from the index size, not from the environment. Verified that the key survives the overlay merge for all four environments.
