### PR TITLE
feat(db-clone): do not perform sed replacements on protected url in version comments, add env file with rds pghost info

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,6 @@ monorepo/**/GEMINI.md
 !monorepo/website/src/pages/docs/GEMINI.md
 
 /tmp/
+
+# Local DB connection settings for scripts/db-clone (created on the bastion)
+scripts/db-clone/env.sh

--- a/scripts/db-clone/README.md
+++ b/scripts/db-clone/README.md
@@ -10,6 +10,21 @@ The script roughly follows these steps:
 
 The script needs to be run on a server with access to the database (e.g. a bastion host on AWS).
 
+## Connection settings (`PGHOST`)
+
+The database host is **not** stored in the repo. Before running the scripts you
+must provide `PGHOST` on the bastion/server, in one of two ways:
+
+- Create `scripts/db-clone/env.sh` by copying the template and filling in the
+  real host. This file is gitignored and stays on the server only:
+
+  ```sh
+  cp env.sh.example env.sh
+  # then edit env.sh and set PGHOST to the RDS cluster endpoint
+  ```
+
+## Passwords
+
 Passwords for the following users need to be set in the environment variables:
 
 - `prod_loculus_user`

--- a/scripts/db-clone/clone-prod-to-staging.sh
+++ b/scripts/db-clone/clone-prod-to-staging.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -Eeuo pipefail
+
 # This script orchestrates the cloning of Keycloak and Loculus databases from production to staging
 # Keycloak is dumped second and loaded first to prevent potential race conditions
 
@@ -14,27 +16,20 @@ STAGING_LOC_DB="pathoplexus_staging_loculus"
 STAGING_KC_USER="staging_keycloak_user"
 STAGING_LOC_USER="staging_loculus_user"
 
-check_command() {
-    if [ $? -ne 0 ]; then
-        echo "Error: $1"
-        exit 1
-    fi
-}
-
 # Note: Could screw up columns and values that contain `prod` etc
 # For now not an issue but might eventually want to be more surgical
 perform_sed_replacements() {
     local file="$1"
     echo "Performing sed replacements on $file..."
     # Abort the script if a line with `@` contains the word "prod" to prevent altering sensitive data
-    if grep '@' "$file" | grep -q 'prod_'; then
+    if awk '/@/ && /prod_/ { found=1; exit } END { exit !found }' "$file"; then
         echo "Error: Found 'prod' in line with '@' in $file. Aborting to prevent changing sensitive data."
         exit 1
     fi
 
     # Do not perform replacements on lines that contain the protected URL
     # see https://github.com/pathoplexus/pathoplexus/issues/1127
-    local protected_url='"https://pathoplexus.org/about/governance/minutes/2026-06-01_EB_Resolutions.pdf"'
+    local protected_url='https://pathoplexus.org/about/governance/minutes/2026-06-01_EB_Resolutions.pdf'
     local placeholder='__PROTECTED_PATHOPLEXUS_URL__'
     sed -i "s#${protected_url}#${placeholder}#g" "$file"
 
@@ -45,29 +40,22 @@ perform_sed_replacements() {
 
     # Restore the protected string
     sed -i "s#${placeholder}#${protected_url}#g" "$file"
-
-    check_command "Failed to perform sed replacements on $file"
 }
 
 echo "Dumping production Loculus database..."
 $CHILD_SCRIPT dump $PROD_LOC_DB $PROD_LOC_DUMP
-check_command "Failed to dump production Loculus database"
 
 echo "Dumping production Keycloak database..."
 $CHILD_SCRIPT dump $PROD_KC_DB $PROD_KC_DUMP
-check_command "Failed to dump production Keycloak database"
-
 perform_sed_replacements $PROD_KC_DUMP
 
 perform_sed_replacements $PROD_LOC_DUMP
 
 echo "Loading Keycloak dump to staging..."
 $CHILD_SCRIPT load $STAGING_KC_DB $PROD_KC_DUMP $STAGING_KC_USER
-check_command "Failed to load Keycloak dump to staging"
 
 echo "Loading Loculus dump to staging..."
 $CHILD_SCRIPT load $STAGING_LOC_DB $PROD_LOC_DUMP $STAGING_LOC_USER
-check_command "Failed to load Loculus dump to staging"
 
 echo "Cloning process completed successfully!"
 echo "Please restart the backend to apply changes."

--- a/scripts/db-clone/clone-prod-to-staging.sh
+++ b/scripts/db-clone/clone-prod-to-staging.sh
@@ -32,10 +32,20 @@ perform_sed_replacements() {
         exit 1
     fi
 
+    # Do not perform replacements on lines that contain the protected URL
+    # see https://github.com/pathoplexus/pathoplexus/issues/1127
+    local protected_url='"https://pathoplexus.org/about/governance/minutes/2026-06-01_EB_Resolutions.pdf"'
+    local placeholder='__PROTECTED_PATHOPLEXUS_URL__'
+    sed -i "s#${protected_url}#${placeholder}#g" "$file"
+
     sed -i 's/prod_loculus_user/staging_loculus_user/g' "$file"
     sed -i 's/prod_keycloak_user/staging_keycloak_user/g' "$file"
     sed -i 's#//pathoplexus.org#//staging.pathoplexus.org#g' "$file"
     sed -i 's#authentication.pathoplexus.org#authentication-staging.pathoplexus.org#g' "$file"
+
+    # Restore the protected string
+    sed -i "s#${placeholder}#${protected_url}#g" "$file"
+
     check_command "Failed to perform sed replacements on $file"
 }
 

--- a/scripts/db-clone/clone.sh
+++ b/scripts/db-clone/clone.sh
@@ -2,9 +2,22 @@
 
 set -x
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-export PGHOST=pathoplexus3.cluster-che6ccwa8oie.eu-central-1.rds.amazonaws.com
+# Load local connection settings (PGHOST) if present.
+if [ -f "$SCRIPT_DIR/env.sh" ]; then
+    # shellcheck disable=SC1091
+    source "$SCRIPT_DIR/env.sh"
+fi
+
 export PGUSER=postgres
+
+if [ -z "${PGHOST:-}" ]; then
+    echo "Error: PGHOST is not set." >&2
+    echo "Export it in the environment on the bastion/server, or create" >&2
+    echo "$SCRIPT_DIR/env.sh (copy env.sh.example). See README.md." >&2
+    exit 1
+fi
 
 print_usage() {
     echo "Usage: $0 <action> <database> <file> [new_owner_username]"

--- a/scripts/db-clone/env.sh.example
+++ b/scripts/db-clone/env.sh.example
@@ -1,0 +1,11 @@
+# Local connection settings for the db-clone scripts.
+#
+# Copy this file to env.sh and fill in the values for your environment:
+#
+#     cp env.sh.example env.sh
+#
+# env.sh is gitignored and is NOT part of the repo. It must be created on the
+# bastion/server by the operator running the clone.
+
+# Hostname of the RDS cluster / Postgres server to connect to.
+export PGHOST="your-cluster.eu-central-1.rds.amazonaws.com"


### PR DESCRIPTION
Ignores doc file links that were affected by sed replacement during db clone.

Additionally makes the following changes/improvements to the db clone script:

- Adds an env file to add rds pghost info (was changed on the bastion but not commited, which I think is good) 

- I replaced check_command with having set -Eeuo pipefail as check_command only check the command right before it (an existing issue - we should have failed if any sed failed but this didnt happen).

ChatGPT then told me it wasnt good practice to use a pipe inside the if statement when activating pipefail as: grep -q is specifically allowed to stop reading input as soon as it finds a match: It finds prod_, so grep -q says, effectively, "I have my answer" and exits successfully with status 0. But the first grep may still be processing the file and trying to write matching lines into the pipe. Since the reader of the pipe has exited, the OS can send the first grep SIGPIPE. It then commonly exits with status 141 (128 + SIGPIPE(13)). to remedy it we can replace the pipe with one single awk statement.

Confirmed with local testing that the diff is gone and regression tests showed clone worked correctly:
<img width="2610" height="1248" alt="image" src="https://github.com/user-attachments/assets/66e194a2-b512-4062-b7d9-ea8203e5a2d0" />


🚀 Preview: Add `preview` label to enable