### PR TITLE
Set the ingest batch size to 1000

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -1782,6 +1782,7 @@ defaultOrganismConfig: &defaultOrganismConfig
     configFile: &defaultIngestConfigFile
       time_between_approve_requests_seconds: 600
       muted_hashes_url: "https://pathoplexus.github.io/curation_data/muted_hashes/muted_hashes.tsv"
+      batch_chunk_size: 1000
 organisms:
   ebola-zaire:
     <<: *defaultOrganismConfig


### PR DESCRIPTION
Replaces #1124, which was opened from a fork so the workflows needing repository secrets could not run. Same single-line change, rebased onto current `main` now that #1123 is merged.

Reduce ingest's batch size for submissions to backend from 10k to 1k to avoid timeouts (these happen frequently when all ingests run at the same time, overwhelming the backend). 1k should avoid syncs getting stuck on previews. There's no real downside to smaller bathes.

🚀 Preview: Add `preview` label to enable