### PR TITLE
Add zika viral usher linkout

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -4131,6 +4131,9 @@ organisms:
         - name: "Country map"
           maxNumberOfRecommendedEntries: 45000
           url: "https://mapoplexus.genomium.org/?url={{[metadata]}}"
+        - name: "Place on viral UShER tree"
+          maxNumberOfRecommendedEntries: 3000
+          url: "https://www.taxonium.org/build?mode=no_genbank&startingTreeUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Zika_virus_Natal_RGN/optimized.pb.gz}}&refGbffUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Zika_virus_Natal_RGN/outgroup_rerooted_NC_035889.1.gbff}}&refFastaUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Zika_virus_Natal_RGN/outgroup_rerooted_NC_035889.1.fa}}&originalMetadataUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Zika_virus_Natal_RGN/metadata.tsv.gz}}&fastaUrl={{[unalignedNucleotideSequences|fasta]}}&metadataUrl={{[metadata]}}&organism={{Zika virus}}"
       extraInputFields:
         - <<: *hostConfig
           desired: false


### PR DESCRIPTION
Adding a linkout to viral usher for Zika

Is the `maxNumberOfRecommendedEntries` reasonable? (Zika is ~11kb)

There are 2 zika trees, we use the one with the same reference used for PPX: https://angiehinrichs.github.io/viral_usher_trees



## Screenshots

Was able to launch a successful UShER workflow using the linkout on the preview:

<img width="1002" height="810" alt="grafik" src="https://github.com/user-attachments/assets/bc61f13b-5ac7-405e-a67b-a670c288fd9d" />

The three sequences were placed on the zika tree (nodes with red circles)

<img width="1332" height="345" alt="grafik" src="https://github.com/user-attachments/assets/8d89d013-5931-465a-97bf-b1de18b1b963" />

🚀 Preview: https://preview-zika-usher.pathoplexus.org