### PR TITLE
fix: make Zika use same sample ID config as the rest

### DIFF
--- a/loculus_values/values.yaml
+++ b/loculus_values/values.yaml
@@ -4133,6 +4133,7 @@ organisms:
           maxNumberOfRecommendedEntries: 3000
           url: "https://www.taxonium.org/build?mode=no_genbank&startingTreeUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Zika_virus_Natal_RGN/optimized.pb.gz}}&refGbffUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Zika_virus_Natal_RGN/outgroup_rerooted_NC_035889.1.gbff}}&refFastaUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Zika_virus_Natal_RGN/outgroup_rerooted_NC_035889.1.fa}}&originalMetadataUrl={{https://angiehinrichs.github.io/viral_usher_trees/trees/Zika_virus_Natal_RGN/metadata.tsv.gz}}&fastaUrl={{[unalignedNucleotideSequences|fasta]}}&metadataUrl={{[metadata]}}&organism={{Zika virus}}"
       extraInputFields:
+        - <<: *idConfig
         - <<: *hostConfig
           desired: false
           required: true


### PR DESCRIPTION
Zika is the only organism that uses Loculus' default sample ID description:

<img width="1207" height="459" alt="grafik" src="https://github.com/user-attachments/assets/72905a9c-3223-4bae-badc-115d57867f62" />

This is because it sets 

```
      extraInputFields:
        - <<: *hostConfig
          desired: false
          required: true
```

Which drops the sample ID configuration that the `defaultOrganismConfig` sets. Fix is to add `- <<: *idConfig`

🚀 Preview: Add `preview` label to enable